### PR TITLE
Fixing, changing import and add error printing

### DIFF
--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -2,13 +2,9 @@
 # Import miscellaneous and utilities librarys
 import os
 import sys
-import h5py
 import tempfile
-import dask as da
 import numpy as np
 import xarray as xr
-import functools as fct
-from typing import Tuple, Optional, Callable
 from dask.distributed import Client, LocalCluster
 
 sys.path.append('..')

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -1,11 +1,13 @@
-
 # Import miscellaneous and utilities librarys
 import os
 import sys
 import tempfile
 import numpy as np
-import xarray as xr
 from dask.distributed import Client, LocalCluster
+
+# needed but not directly used
+import h5py
+import xarray as xr
 
 sys.path.append('..')
 import utilities as utils

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -10,8 +10,9 @@ import xarray as xr
 import functools as fct
 from typing import Tuple, Optional, Callable
 from dask.distributed import Client, LocalCluster
+
 sys.path.append('..')
-import utilities  as utils
+import utilities as utils
 import minian_utilities as min_utils
 
 # Import for MiniAn lib
@@ -65,7 +66,7 @@ try:
     for arg in sys.argv[1:]:
         exec(arg)
 except SyntaxError:
-    utils.utils.print_to_intercept(ADVANCED_BAD_TYPE)
+    utils.print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
 
 if not danse_parameters:
@@ -278,14 +279,14 @@ if __name__ == "__main__":
     try:
         varr_ref = denoise(varr_ref, **params_denoise)
     except TypeError:
-        utils.utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("denoise"))
+        utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("denoise"))
         sys.exit()
     # 3. Background removal
     print(PREPROC_REMOV_BACKG, flush=True)
     try:
         varr_ref = remove_background(varr_ref, **params_remove_background)
     except TypeError:
-        utils.utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("remove_background"))
+        utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("remove_background"))
         sys.exit()
     # Save
     print(PREPROC_SAVE, flush=True)

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -352,7 +352,8 @@ if __name__ == "__main__":
         except TypeError:
             print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
-    except:
+    except Exception as error:
+        print("An error occurred:", type(error).__name__, "-", error, flush=True)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -389,7 +390,8 @@ if __name__ == "__main__":
         f = save_minian(f.rename("f"), intpath, overwrite=True)
         b = save_minian(b.rename("b"), intpath, overwrite=True)
 
-    except:
+    except Exception as error:
+        print("An error occurred:", type(error).__name__, "-", error, flush=True)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -451,7 +453,8 @@ if __name__ == "__main__":
                             chunks={"unit_id": -1, "frame": chk["frame"]})
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
-    except:
+    except Exception as error:
+        print("An error occurred:", type(error).__name__, "-", error, flush=True)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -495,7 +498,8 @@ if __name__ == "__main__":
 
         AC = compute_AtC(A, C_chk)
 
-    except:
+    except Exception as error:
+        print("An error occurred:", type(error).__name__, "-", error, flush=True)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -397,7 +397,7 @@ if __name__ == "__main__":
     ### CNMF 1st itteration ###
     try:
         # 1. Estimate spatial noise
-        print(RUN_CNMF_ESTIM_NOISE.fromat("1st"), flush=True)
+        print(RUN_CNMF_ESTIM_NOISE.format("1st"), flush=True)
         try:
             sn_spatial = get_noise_fft(Y_hw_chk, **params_get_noise_fft)
         except TypeError:
@@ -405,7 +405,7 @@ if __name__ == "__main__":
             sys.exit()
         sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
         # 2. First spatial update
-        print(RUN_CNMF_UPDAT_SPATIAL.fromat("1st"), flush=True)
+        print(RUN_CNMF_UPDAT_SPATIAL.format("1st"), flush=True)
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
@@ -414,7 +414,7 @@ if __name__ == "__main__":
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
         # 3. Update background
-        print(RUN_CNMF_UPDAT_BACKG.fromat("1st"), flush=True)
+        print(RUN_CNMF_UPDAT_BACKG.format("1st"), flush=True)
         b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
         A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1},)
         b = save_minian(b_new.rename("b"), intpath, overwrite=True)
@@ -422,7 +422,7 @@ if __name__ == "__main__":
         C = save_minian(C_new.rename("C"), intpath, overwrite=True)
         C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
         # 4. First temporal update
-        print(RUN_CNMF_UPDAT_TEMP.fromat("1st"), flush=True)
+        print(RUN_CNMF_UPDAT_TEMP.format("1st"), flush=True)
         YrA = save_minian(compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"), intpath, overwrite=True,
                         chunks={"unit_id": 1, "frame": -1})
         try:
@@ -437,14 +437,14 @@ if __name__ == "__main__":
         c0 = save_minian(c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         A = A.sel(unit_id=C.coords["unit_id"].values)
         # 5. Merge components
-        print(RUN_CNMF_MERG_COMP.fromat("1st"), flush=True)
+        print(RUN_CNMF_MERG_COMP.format("1st"), flush=True)
         try:
             A_mrg, C_mrg, [sig_mrg] = unit_merge(A, C, [C + b0 + c0], **params_unit_merge)
         except TypeError:
             print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
             sys.exit()
         # Save
-        print(RUN_CNMF_SAVE_INTERMED.fromat("1st"), flush=True)
+        print(RUN_CNMF_SAVE_INTERMED.format("1st"), flush=True)
         A = save_minian(A_mrg.rename("A_mrg"), intpath, overwrite=True)
         C = save_minian(C_mrg.rename("C_mrg"), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_mrg_chk"), intpath, overwrite=True,

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -33,6 +33,38 @@ from minian.motion_correction import apply_transform, estimate_motion
 from multiprocessing import freeze_support
 freeze_support()
 
+# Text definitions
+ADVANCED_BAD_TYPE   = "One of the advanced settings is not of a python type"
+LOAD_DATA           = "Loading dataset to MiniAn..."
+ONE_PARM_WRONG_TYPE = "One parameter of {0} function is of the wrong type"
+NO_CELLS_FOUND      = "No cells where found"
+PREPROCESS          = "Pre-processing..."
+PREPROC_REMOVE_GLOW = "Pre-processing: removing glow..."
+PREPROC_DENOISING   = "Pre-processing: denoising..."
+PREPROC_REMOV_BACKG = "Pre-processing: removing background..."
+PREPROC_SAVE        = "Pre-processing: saving..."
+CORRECT_MOTION_ESTIM_SHIFT  = "Correcting motion: estimating shifts..."
+CORRECT_MOTION_APPLY_SHIFT  = "Correcting motion: applying shifts..."
+PREP_DATA_INIT              = "Preparing data for initialization..."
+INIT_SEEDS                  = "Initializing seeds..."
+INIT_SEEDS_PNR_REFI         = "Initializing seeds: PNR refinement..."
+INIT_SEEDS_KOLSM_REF        = "Initializing seeds: Kolmogorov-Smirnov refinement..."
+INIT_SEEDS_MERG             = "Initializing seeds: merging..."
+INIT_COMP                   = "Initializing components..."
+INIT_COMP_SPATIAL           = "Initializing components: spatial..."
+INIT_COMP_TEMP              = "Initializing components: temporal..."
+INIT_COMP_MERG              = "Initializing components: merging..."
+INIT_COMP_BACKG             = "Initializing components: background..."
+RUN_CNMF_ITT                = "Running CNMF {0} itteration: "
+RUN_CNMF_ESTIM_NOISE        = RUN_CNMF_ITT + "estimating noise..."
+RUN_CNMF_UPDAT_SPATIAL      = RUN_CNMF_ITT + "updating spatial components..."
+RUN_CNMF_UPDAT_BACKG        = RUN_CNMF_ITT + "updating background components..."
+RUN_CNMF_UPDAT_TEMP         = RUN_CNMF_ITT + "updating temporal components..."
+RUN_CNMF_MERG_COMP          = RUN_CNMF_ITT + "merging components..."
+RUN_CNMF_SAVE_INTERMED      = RUN_CNMF_ITT + "saving intermediate results..."
+SAVING_FINAL                = "Saving final results..."
+SAVING_TO_DORIC             = "Saving data to doric file..."
+
 kwargs = {}
 params_doric = {}
 danse_parameters = {}
@@ -41,7 +73,7 @@ try:
     for arg in sys.argv[1:]:
         exec(arg)
 except SyntaxError:
-    print_to_intercept("One of the advanced settings is not of a python type")
+    print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
 
 if not danse_parameters:
@@ -236,7 +268,7 @@ if __name__ == "__main__":
     subset = {"frame": slice(0, None)}
 
     ### Load and chunk the data ###
-    print("Loading dataset to MiniAn...", flush=True)
+    print(LOAD_DATA, flush=True)
     varr, file_ = load_doric_to_xarray(**params_load_doric)
     chk, _ = get_optimal_chk(varr, **params_get_optimal_chk)
     varr = save_minian(varr.chunk({"frame": chk["frame"], "height": -1, "width": -1}).rename("varr"),
@@ -244,51 +276,51 @@ if __name__ == "__main__":
     varr_ref = varr.sel(subset)
 
     ### Pre-process data ###
-    print("Pre-processing...", flush=True)
+    print(PREPROCESS, flush=True)
     # 1. Glow removal
-    print("Pre-processing: removing glow...", flush=True)
+    print(PREPROC_REMOVE_GLOW, flush=True)
     varr_min = varr_ref.min("frame").compute()
     varr_ref = varr_ref - varr_min
     # 2. Denoise
-    print("Pre-processing: denoising...", flush=True)
+    print(PREPROC_DENOISING, flush=True)
     try:
         varr_ref = denoise(varr_ref, **params_denoise)
     except TypeError:
-        print_to_intercept("One parameter of denoise function is of the wrong type")
+        print_to_intercept(ONE_PARM_WRONG_TYPE.format("denoise"))
         sys.exit()
     # 3. Background removal
-    print("Pre-processing: removing background...", flush=True)
+    print(PREPROC_REMOV_BACKG, flush=True)
     try:
         varr_ref = remove_background(varr_ref, **params_remove_background)
     except TypeError:
-        print_to_intercept("One parameter of remove_background function is of the wrong type")
+        print_to_intercept(ONE_PARM_WRONG_TYPE.format("remove_background"))
         sys.exit()
     # Save
-    print("Pre-processing: saving...", flush=True)
+    print(PREPROC_SAVE, flush=True)
     varr_ref = save_minian(varr_ref.rename("varr_ref"), intpath, overwrite=True)
 
     ### Motion correction ###
     if parameters["CorrectMotion"]:
-        print("Correcting motion: estimating shifts...", flush=True)
+        print(CORRECT_MOTION_ESTIM_SHIFT, flush=True)
         try:
             motion = estimate_motion(varr_ref, **params_estimate_motion)
         except TypeError:
-            print_to_intercept("One parameter of estimate_motion function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("estimate_motion"))
             sys.exit()
         motion = save_minian(motion.rename("motion").chunk({"frame": chk["frame"]}), **params_save_minian)
-        print("Correcting motion: applying shifts...", flush=True)
+        print(CORRECT_MOTION_APPLY_SHIFT, flush=True)
         Y = apply_transform(varr_ref, motion, **params_apply_transform)
 
     else:
         Y = varr_ref
 
-    print("Preparing data for initialization...", flush=True)
+    print(PREP_DATA_INIT, flush=True)
     Y_fm_chk = save_minian(Y.astype(float).rename("Y_fm_chk"), intpath, overwrite=True)
     Y_hw_chk = save_minian(Y_fm_chk.rename("Y_hw_chk"), intpath, overwrite=True,
                            chunks={"frame": -1, "height": chk["height"], "width": chk["width"]})
 
     ### Seed initialization ###
-    print("Initializing seeds...", flush=True)
+    print(INIT_SEEDS, flush=True)
     try:
         # 1. Compute max projection
         max_proj = save_minian(Y_fm_chk.max("frame").rename("max_proj"), **params_save_minian).compute()
@@ -296,93 +328,93 @@ if __name__ == "__main__":
         try:
             seeds = seeds_init(Y_fm_chk, **params_seeds_init)
         except TypeError:
-            print_to_intercept("One parameter of seeds_init function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_init"))
             sys.exit()
         # 3. Peak-Noise-Ratio refine
-        print("Initializing seeds: PNR refinement...", flush=True)
+        print(INIT_SEEDS_PNR_REFI, flush=True)
         try:
             seeds, pnr, gmm = pnr_refine(Y_hw_chk, seeds, **params_pnr_refine)
         except TypeError:
-            print_to_intercept("One parameter of pnr_refine function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("pnr_refine"))
             sys.exit()
         # 4. Kolmogorov-Smirnov refine
-        print("Initializing seeds: Kolmogorov-Smirnov refinement...", flush=True)
+        print(INIT_SEEDS_KOLSM_REF, flush=True)
         try:
             seeds = ks_refine(Y_hw_chk, seeds, **params_ks_refine)
         except TypeError:
-            print_to_intercept("One parameter of ks_refine function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("ks_refine"))
             sys.exit()
         # 5. Merge seeds
-        print("Initializing seeds: merging...", flush=True)
+        print(INIT_SEEDS_MERG, flush=True)
         seeds_final = seeds[seeds["mask_ks"] & seeds["mask_pnr"]].reset_index(drop=True)
         try:
             seeds_final = seeds_merge(Y_hw_chk, max_proj, seeds_final, **params_seeds_merge)
         except TypeError:
-            print_to_intercept("One parameter of seeds_merge function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
     except:
-        print_to_intercept("No cells where found")
+        print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
     ### Component initialization ###
-    print("Initializing components...", flush=True)
+    print(INIT_COMP, flush=True)
     try:
         # 1. Initialize spatial
-        print("Initializing components: spatial...", flush=True)
+        print(INIT_COMP_SPATIAL, flush=True)
         try:
             A_init = initA(Y_hw_chk, seeds_final[seeds_final["mask_mrg"]], **params_initA)
         except TypeError:
-            print_to_intercept("One parameter of initA function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("initA"))
             sys.exit()
         A_init = save_minian(A_init.rename("A_init"), intpath, overwrite=True)
         # 2. Initialize temporal
-        print("Initializing components: temporal...", flush=True)
+        print(INIT_COMP_TEMP, flush=True)
         C_init = initC(Y_fm_chk, A_init)
         C_init = save_minian(C_init.rename("C_init"), intpath, overwrite=True,
                             chunks={"unit_id": 1, "frame": -1})
         # 3. Merge components
-        print("Initializing components: merging...", flush=True)
+        print(INIT_COMP_MERG, flush=True)
         try:
             A, C = unit_merge(A_init, C_init, **params_unit_merge)
         except TypeError:
-            print_to_intercept("One parameter of unit_merge function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
             sys.exit()
         A = save_minian(A.rename("A"), intpath, overwrite=True)
         C = save_minian(C.rename("C"), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True,
                             chunks={"unit_id": -1, "frame": chk["frame"]})
         # 4. Initialize background
-        print("Initializing components: background...", flush=True)
+        print(INIT_COMP_BACKG, flush=True)
         b, f = update_background(Y_fm_chk, A, C_chk)
         f = save_minian(f.rename("f"), intpath, overwrite=True)
         b = save_minian(b.rename("b"), intpath, overwrite=True)
 
     except:
-        print_to_intercept("No cells where found")
+        print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
 
     ### CNMF 1st itteration ###
     try:
         # 1. Estimate spatial noise
-        print("Running CNMF 1st itteration: estimating noise...", flush=True)
+        print(RUN_CNMF_ESTIM_NOISE.fromat("1st"), flush=True)
         try:
             sn_spatial = get_noise_fft(Y_hw_chk, **params_get_noise_fft)
         except TypeError:
-            print_to_intercept("One parameter of get_noise_fft function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("get_noise_fft"))
             sys.exit()
         sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
         # 2. First spatial update
-        print("Running CNMF 1st itteration: updating spatial components...", flush=True)
+        print(RUN_CNMF_UPDAT_SPATIAL.fromat("1st"), flush=True)
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
-            print_to_intercept("One parameter of update_spatial function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_spatial"))
             sys.exit()
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
         # 3. Update background
-        print("Running CNMF 1st itteration: updating background components...", flush=True)
+        print(RUN_CNMF_UPDAT_BACKG.fromat("1st"), flush=True)
         b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
         A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1},)
         b = save_minian(b_new.rename("b"), intpath, overwrite=True)
@@ -390,13 +422,13 @@ if __name__ == "__main__":
         C = save_minian(C_new.rename("C"), intpath, overwrite=True)
         C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
         # 4. First temporal update
-        print("Running CNMF 1st itteration: updating temporal components...", flush=True)
+        print(RUN_CNMF_UPDAT_TEMP.fromat("1st"), flush=True)
         YrA = save_minian(compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"), intpath, overwrite=True,
                         chunks={"unit_id": 1, "frame": -1})
         try:
             C_new, S_new, b0_new, c0_new, g, mask = update_temporal(A, C, YrA=YrA, **params_update_temporal)
         except TypeError:
-            print_to_intercept("One parameter of update_temporal function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
             sys.exit()
         C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]},)
@@ -405,14 +437,14 @@ if __name__ == "__main__":
         c0 = save_minian(c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         A = A.sel(unit_id=C.coords["unit_id"].values)
         # 5. Merge components
-        print("Running CNMF 1st itteration: merging components...", flush=True)
+        print(RUN_CNMF_MERG_COMP.fromat("1st"), flush=True)
         try:
             A_mrg, C_mrg, [sig_mrg] = unit_merge(A, C, [C + b0 + c0], **params_unit_merge)
         except TypeError:
-            print_to_intercept("One parameter of unit_merge function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
             sys.exit()
         # Save
-        print("Running CNMF 1st itteration: saving intermediate results...", flush=True)
+        print(RUN_CNMF_SAVE_INTERMED.fromat("1st"), flush=True)
         A = save_minian(A_mrg.rename("A_mrg"), intpath, overwrite=True)
         C = save_minian(C_mrg.rename("C_mrg"), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_mrg_chk"), intpath, overwrite=True,
@@ -420,23 +452,23 @@ if __name__ == "__main__":
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
     except:
-        print_to_intercept("No cells where found")
+        print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
 
     ### CNMF 2nd itteration ###
     try:
         # 5. Second spatial update
-        print("Running CNMF 2nd itteration: updating spatial components...", flush=True)
+        print(RUN_CNMF_UPDAT_SPATIAL.format("2nd"), flush=True)
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
-            print_to_intercept("One parameter of update_spatial function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_spatial"))
             sys.exit()
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
         # 6. Second background update
-        print("Running CNMF 2nd itteration: updating background components...", flush=True)
+        print(RUN_CNMF_UPDAT_BACKG.format("2nd"), flush=True)
         b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
         A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1},)
         b = save_minian(b_new.rename("b"), intpath, overwrite=True)
@@ -444,16 +476,16 @@ if __name__ == "__main__":
         C = save_minian(C_new.rename("C"), intpath, overwrite=True)
         C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
         # 7. Second temporal update
-        print("Running CNMF 2nd itteration: updating temporal components...", flush=True)
+        print(RUN_CNMF_UPDAT_TEMP.format("2nd"), flush=True)
         YrA = save_minian(compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"), intpath, overwrite=True,
                         chunks={"unit_id": 1, "frame": -1})
         try:
             C_new, S_new, b0_new, c0_new, g, mask = update_temporal(A, C, YrA=YrA, **params_update_temporal)
         except TypeError:
-            print_to_intercept("One parameter of update_temporal function is of the wrong type")
+            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
             sys.exit()
         # Save
-        print("Running CNMF 2nd itteration: saving intermediate results...", flush=True)
+        print(RUN_CNMF_SAVE_INTERMED.format("2nd"), flush=True)
         C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]})
         S = save_minian(S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
@@ -464,11 +496,11 @@ if __name__ == "__main__":
         AC = compute_AtC(A, C_chk)
 
     except:
-        print_to_intercept("No cells where found")
+        print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
     ### Save final results ###
-    print("Saving final results...", flush=True)
+    print(SAVING_FINAL, flush=True)
     A = save_minian(A.rename("A"), **params_save_minian)
     C = save_minian(C.rename("C"), **params_save_minian)
     AC = save_minian(AC.rename("AC"), **params_save_minian)
@@ -479,7 +511,7 @@ if __name__ == "__main__":
     f = save_minian(f.rename("f"), **params_save_minian)
 
     ### Save results to doric file ###
-    print("Saving data to doric file...", flush=True)
+    print(SAVING_TO_DORIC, flush=True)
     # Get the path from the source data
     h5path = params_load_doric['h5path']
     if h5path[0] == '/':

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -11,7 +11,7 @@ import xarray as xr
 
 sys.path.append('..')
 import utilities as utils
-import minian_utilities as min_utils
+import minian_utilities as mn_utils
 
 # Import for MiniAn lib
 from minian.utilities import TaskAnnotation, get_optimal_chk, custom_arr_optimize, save_minian, open_minian
@@ -68,7 +68,7 @@ except SyntaxError:
     utils.print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
 except Exception as error:
-    min_utils.print_error(error)
+    mn_utils.print_error(error)
     sys.exit()
 
 if not danse_parameters: # for backwards compatibility
@@ -139,15 +139,15 @@ params_get_optimal_chk = {
     "dtype": float
 }
 if "get_optimal_chk" in advanced_settings:
-    params_get_optimal_chk, advanced_settings["get_optimal_chk"] = min_utils.set_advanced_parameters_for_func_params(params_get_optimal_chk, advanced_settings["get_optimal_chk"], get_optimal_chk)
+    params_get_optimal_chk, advanced_settings["get_optimal_chk"] = mn_utils.set_advanced_parameters_for_func_params(params_get_optimal_chk, advanced_settings["get_optimal_chk"], get_optimal_chk)
 
 
 params_denoise = {
     'method': 'median',
-    'ksize': min_utils.round_down_to_odd(neuron_diameter[-1]/2.0) # half of the maximum diameter
+    'ksize': mn_utils.round_down_to_odd(neuron_diameter[-1]/2.0) # half of the maximum diameter
 }
 if "denoise" in advanced_settings:
-    params_denoise, advanced_settings["denoise"] = min_utils.set_advanced_parameters_for_denoise(params_denoise, advanced_settings["denoise"], denoise)
+    params_denoise, advanced_settings["denoise"] = mn_utils.set_advanced_parameters_for_denoise(params_denoise, advanced_settings["denoise"], denoise)
 
 
 params_remove_background = {
@@ -155,21 +155,21 @@ params_remove_background = {
     'wnd': np.ceil(neuron_diameter[-1]) # largest neuron diameter
 }
 if "remove_background" in advanced_settings:
-    params_remove_background, advanced_settings["remove_background"] = min_utils.set_advanced_parameters_for_func_params(params_remove_background, advanced_settings["remove_background"], remove_background)
+    params_remove_background, advanced_settings["remove_background"] = mn_utils.set_advanced_parameters_for_func_params(params_remove_background, advanced_settings["remove_background"], remove_background)
 
 
 params_estimate_motion = {
     'dim': 'frame'
 }
 if "estimate_motion" in advanced_settings:
-    params_estimate_motion, advanced_settings["estimate_motion"] = min_utils.set_advanced_parameters_for_estimate_motion(params_estimate_motion, advanced_settings["estimate_motion"], estimate_motion)
+    params_estimate_motion, advanced_settings["estimate_motion"] = mn_utils.set_advanced_parameters_for_estimate_motion(params_estimate_motion, advanced_settings["estimate_motion"], estimate_motion)
 
 
 params_apply_transform = {
     'fill': 0
 }
 if "apply_transform" in advanced_settings:
-    params_apply_transform, advanced_settings["apply_transform"] = min_utils.set_advanced_parameters_for_func_params(params_apply_transform, advanced_settings["apply_transform"], apply_transform)
+    params_apply_transform, advanced_settings["apply_transform"] = mn_utils.set_advanced_parameters_for_func_params(params_apply_transform, advanced_settings["apply_transform"], apply_transform)
 
 
 wnd = 60 # time window of 60 seconds
@@ -181,7 +181,7 @@ params_seeds_init = {
     'diff_thres': 3
 }
 if "seeds_init" in advanced_settings:
-    params_seeds_init, advanced_settings["seeds_init"] = min_utils.set_advanced_parameters_for_func_params(params_seeds_init, advanced_settings["seeds_init"], seeds_init)
+    params_seeds_init, advanced_settings["seeds_init"] = mn_utils.set_advanced_parameters_for_func_params(params_seeds_init, advanced_settings["seeds_init"], seeds_init)
 
 
 params_pnr_refine = {
@@ -189,14 +189,14 @@ params_pnr_refine = {
     "thres": 1
 }
 if "pnr_refine" in advanced_settings:
-    params_pnr_refine, advanced_settings["pnr_refine"] = min_utils.set_advanced_parameters_for_func_params(params_pnr_refine, advanced_settings["pnr_refine"], pnr_refine)
+    params_pnr_refine, advanced_settings["pnr_refine"] = mn_utils.set_advanced_parameters_for_func_params(params_pnr_refine, advanced_settings["pnr_refine"], pnr_refine)
 
 
 params_ks_refine = {
     "sig": 0.05
 }
 if "ks_refine" in advanced_settings:
-    params_ks_refine, advanced_settings["ks_refine"] = min_utils.set_advanced_parameters_for_func_params(params_ks_refine, advanced_settings["ks_refine"], ks_refine)
+    params_ks_refine, advanced_settings["ks_refine"] = mn_utils.set_advanced_parameters_for_func_params(params_ks_refine, advanced_settings["ks_refine"], ks_refine)
 
 
 params_seeds_merge = {
@@ -205,7 +205,7 @@ params_seeds_merge = {
     'noise_freq': noise_freq
 }
 if "seeds_merge" in advanced_settings:
-    params_seeds_merge, advanced_settings["seeds_merge"] = min_utils.set_advanced_parameters_for_func_params(params_seeds_merge, advanced_settings["seeds_merge"], seeds_merge)
+    params_seeds_merge, advanced_settings["seeds_merge"] = mn_utils.set_advanced_parameters_for_func_params(params_seeds_merge, advanced_settings["seeds_merge"], seeds_merge)
 
 
 params_initA = {
@@ -214,21 +214,21 @@ params_initA = {
     'noise_freq': noise_freq
 }
 if "initA" in advanced_settings:
-    params_initA, advanced_settings["initA"] = min_utils.set_advanced_parameters_for_func_params(params_initA, advanced_settings["initA"], initA)
+    params_initA, advanced_settings["initA"] = mn_utils.set_advanced_parameters_for_func_params(params_initA, advanced_settings["initA"], initA)
 
 
 params_unit_merge = {
     'thres_corr': thres_corr
 }
 if "unit_merge" in advanced_settings:
-    params_unit_merge, advanced_settings["unit_merge"] = min_utils.set_advanced_parameters_for_func_params(params_unit_merge, advanced_settings["unit_merge"], unit_merge)
+    params_unit_merge, advanced_settings["unit_merge"] = mn_utils.set_advanced_parameters_for_func_params(params_unit_merge, advanced_settings["unit_merge"], unit_merge)
 
 
 params_get_noise_fft = {
     'noise_range': (noise_freq, 0.5)
 }
 if "get_noise_fft" in advanced_settings:
-    params_get_noise_fft, advanced_settings["get_noise_fft"] = min_utils.set_advanced_parameters_for_func_params(params_get_noise_fft, advanced_settings["get_noise_fft"], get_noise_fft)
+    params_get_noise_fft, advanced_settings["get_noise_fft"] = mn_utils.set_advanced_parameters_for_func_params(params_get_noise_fft, advanced_settings["get_noise_fft"], get_noise_fft)
 
 
 params_update_spatial = {
@@ -237,7 +237,7 @@ params_update_spatial = {
     'size_thres': (np.ceil(0.9*(np.pi*neuron_diameter[0]/2)**2), np.ceil(1.1*(np.pi*neuron_diameter[-1]/2)**2))
 }
 if "update_spatial" in advanced_settings:
-    params_update_spatial, advanced_settings["update_spatial"] = min_utils.set_advanced_parameters_for_func_params(params_update_spatial, advanced_settings["update_spatial"], update_spatial)
+    params_update_spatial, advanced_settings["update_spatial"] = mn_utils.set_advanced_parameters_for_func_params(params_update_spatial, advanced_settings["update_spatial"], update_spatial)
 
 
 params_update_temporal = {
@@ -248,7 +248,7 @@ params_update_temporal = {
     'jac_thres': 0.2
 }
 if "update_temporal" in advanced_settings:
-    params_update_temporal, advanced_settings["update_temporal"] = min_utils.set_advanced_parameters_for_func_params(params_update_temporal, advanced_settings["update_temporal"], update_temporal)
+    params_update_temporal, advanced_settings["update_temporal"] = mn_utils.set_advanced_parameters_for_func_params(params_update_temporal, advanced_settings["update_temporal"], update_temporal)
 
 # Update AdvancedSettings in params_doric
 parameters["AdvancedSettings"] = advanced_settings.copy()
@@ -268,7 +268,7 @@ if __name__ == "__main__":
 
     ### Load and chunk the data ###
     print(LOAD_DATA, flush=True)
-    varr, file_ = min_utils.load_doric_to_xarray(**params_load_doric)
+    varr, file_ = mn_utils.load_doric_to_xarray(**params_load_doric)
     chk, _ = get_optimal_chk(varr, **params_get_optimal_chk)
     varr = save_minian(varr.chunk({"frame": chk["frame"], "height": -1, "width": -1}).rename("varr"),
                        intpath, overwrite=True)
@@ -352,7 +352,7 @@ if __name__ == "__main__":
             utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
     except Exception as error:
-        min_utils.print_error(error)
+        mn_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -390,7 +390,7 @@ if __name__ == "__main__":
         b = save_minian(b.rename("b"), intpath, overwrite=True)
 
     except Exception as error:
-        min_utils.print_error(error)
+        mn_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -453,7 +453,7 @@ if __name__ == "__main__":
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
     except Exception as error:
-        min_utils.print_error(error)
+        mn_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -498,7 +498,7 @@ if __name__ == "__main__":
         AC = compute_AtC(A, C_chk)
 
     except Exception as error:
-        min_utils.print_error(error)
+        mn_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -544,7 +544,7 @@ if __name__ == "__main__":
     if parameters["SpatialDownsample"] > 1:
         parameters["BinningFactor"] = parameters["SpatialDownsample"]
 
-    min_utils.save_minian_to_doric(
+    mn_utils.save_minian_to_doric(
         Y, A, C, AC, S,
         fr=fr,
         bits_count=attrs['BitsCount'],

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -25,6 +25,7 @@ from multiprocessing import freeze_support
 freeze_support()
 
 # Text definitions
+START_CLUSTER       = "Starting cluster..."
 ADVANCED_BAD_TYPE   = "One of the advanced settings is not of a python type"
 LOAD_DATA           = "Loading dataset to MiniAn..."
 ONE_PARM_WRONG_TYPE = "One parameter of {0} function is of the wrong type"
@@ -248,7 +249,7 @@ parameters["AdvancedSettings"] = advanced_settings.copy()
 if __name__ == "__main__":
 
     # Start cluster
-    print("Starting cluster...", flush=True)
+    print(START_CLUSTER, flush=True)
     cluster = LocalCluster(**params_LocalCluster)
     annt_plugin = TaskAnnotation()
     cluster.scheduler.add_plugin(annt_plugin)

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -35,6 +35,7 @@ freeze_support()
 
 kwargs = {}
 params_doric = {}
+danse_parameters = {}
 
 try:
     for arg in sys.argv[1:]:
@@ -43,8 +44,8 @@ except SyntaxError:
     print_to_intercept("One of the advanced settings is not of a python type")
     sys.exit()
 
-
-danse_parameters = {"file_path": kwargs , "parameters": params_doric}
+if not danse_parameters:
+    danse_parameters = {"file_path": kwargs , "parameters": params_doric}
 
 file_path   = danse_parameters.get("file_path", {})
 parameters  = danse_parameters.get("parameters", {})
@@ -454,8 +455,7 @@ if __name__ == "__main__":
         # Save
         print("Running CNMF 2nd itteration: saving intermediate results...", flush=True)
         C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
-        C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True,
-                            chunks={"unit_id": -1, "frame": chk["frame"]})
+        C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]})
         S = save_minian(S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         b0 = save_minian(b0_new.rename("b0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         c0 = save_minian(c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -352,7 +352,7 @@ if __name__ == "__main__":
             utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
     except Exception as error:
-        mn_utils.print_error(error)
+        utils.print_error(error, INIT_SEEDS)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -390,7 +390,7 @@ if __name__ == "__main__":
         b = save_minian(b.rename("b"), intpath, overwrite=True)
 
     except Exception as error:
-        mn_utils.print_error(error)
+        utils.print_error(error, INIT_COMP)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -453,7 +453,7 @@ if __name__ == "__main__":
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
     except Exception as error:
-        mn_utils.print_error(error)
+        utils.print_error(error, RUN_CNMF_ITT.format("1st"))
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -498,7 +498,7 @@ if __name__ == "__main__":
         AC = compute_AtC(A, C_chk)
 
     except Exception as error:
-        mn_utils.print_error(error)
+        utils.print_error(error, RUN_CNMF_ITT.format("2nd"))
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -11,7 +11,7 @@ import functools as fct
 from typing import Tuple, Optional, Callable
 from dask.distributed import Client, LocalCluster
 sys.path.append('..')
-from utilities import get_frequency, load_attributes, print_to_intercept
+import utilities  as utils
 from minian_utilities import (
     load_doric_to_xarray,
     save_minian_to_doric,
@@ -74,7 +74,7 @@ try:
     for arg in sys.argv[1:]:
         exec(arg)
 except SyntaxError:
-    print_to_intercept(ADVANCED_BAD_TYPE)
+    utils.utils.print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
 
 if not danse_parameters:
@@ -85,7 +85,7 @@ parameters  = danse_parameters.get("parameters", {})
 
 tmpDir  = tempfile.TemporaryDirectory(prefix="minian_")
 dpath   = tmpDir.name
-fr      = get_frequency(file_path["fname"], file_path['h5path']+'Time')
+fr      = utils.get_frequency(file_path["fname"], file_path['h5path']+'Time')
 
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
@@ -287,14 +287,14 @@ if __name__ == "__main__":
     try:
         varr_ref = denoise(varr_ref, **params_denoise)
     except TypeError:
-        print_to_intercept(ONE_PARM_WRONG_TYPE.format("denoise"))
+        utils.utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("denoise"))
         sys.exit()
     # 3. Background removal
     print(PREPROC_REMOV_BACKG, flush=True)
     try:
         varr_ref = remove_background(varr_ref, **params_remove_background)
     except TypeError:
-        print_to_intercept(ONE_PARM_WRONG_TYPE.format("remove_background"))
+        utils.utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("remove_background"))
         sys.exit()
     # Save
     print(PREPROC_SAVE, flush=True)
@@ -306,7 +306,7 @@ if __name__ == "__main__":
         try:
             motion = estimate_motion(varr_ref, **params_estimate_motion)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("estimate_motion"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("estimate_motion"))
             sys.exit()
         motion = save_minian(motion.rename("motion").chunk({"frame": chk["frame"]}), **params_save_minian)
         print(CORRECT_MOTION_APPLY_SHIFT, flush=True)
@@ -329,21 +329,21 @@ if __name__ == "__main__":
         try:
             seeds = seeds_init(Y_fm_chk, **params_seeds_init)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_init"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_init"))
             sys.exit()
         # 3. Peak-Noise-Ratio refine
         print(INIT_SEEDS_PNR_REFI, flush=True)
         try:
             seeds, pnr, gmm = pnr_refine(Y_hw_chk, seeds, **params_pnr_refine)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("pnr_refine"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("pnr_refine"))
             sys.exit()
         # 4. Kolmogorov-Smirnov refine
         print(INIT_SEEDS_KOLSM_REF, flush=True)
         try:
             seeds = ks_refine(Y_hw_chk, seeds, **params_ks_refine)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("ks_refine"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("ks_refine"))
             sys.exit()
         # 5. Merge seeds
         print(INIT_SEEDS_MERG, flush=True)
@@ -351,11 +351,11 @@ if __name__ == "__main__":
         try:
             seeds_final = seeds_merge(Y_hw_chk, max_proj, seeds_final, **params_seeds_merge)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
     except Exception as error:
         print_error(error)
-        print_to_intercept(NO_CELLS_FOUND)
+        utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
     ### Component initialization ###
@@ -366,7 +366,7 @@ if __name__ == "__main__":
         try:
             A_init = initA(Y_hw_chk, seeds_final[seeds_final["mask_mrg"]], **params_initA)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("initA"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("initA"))
             sys.exit()
         A_init = save_minian(A_init.rename("A_init"), intpath, overwrite=True)
         # 2. Initialize temporal
@@ -379,7 +379,7 @@ if __name__ == "__main__":
         try:
             A, C = unit_merge(A_init, C_init, **params_unit_merge)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
             sys.exit()
         A = save_minian(A.rename("A"), intpath, overwrite=True)
         C = save_minian(C.rename("C"), intpath, overwrite=True)
@@ -393,7 +393,7 @@ if __name__ == "__main__":
 
     except Exception as error:
         print_error(error)
-        print_to_intercept(NO_CELLS_FOUND)
+        utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
 
@@ -404,7 +404,7 @@ if __name__ == "__main__":
         try:
             sn_spatial = get_noise_fft(Y_hw_chk, **params_get_noise_fft)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("get_noise_fft"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("get_noise_fft"))
             sys.exit()
         sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
         # 2. First spatial update
@@ -412,7 +412,7 @@ if __name__ == "__main__":
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_spatial"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_spatial"))
             sys.exit()
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
@@ -431,7 +431,7 @@ if __name__ == "__main__":
         try:
             C_new, S_new, b0_new, c0_new, g, mask = update_temporal(A, C, YrA=YrA, **params_update_temporal)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
             sys.exit()
         C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]},)
@@ -444,7 +444,7 @@ if __name__ == "__main__":
         try:
             A_mrg, C_mrg, [sig_mrg] = unit_merge(A, C, [C + b0 + c0], **params_unit_merge)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
             sys.exit()
         # Save
         print(RUN_CNMF_SAVE_INTERMED.format("1st"), flush=True)
@@ -456,7 +456,7 @@ if __name__ == "__main__":
 
     except Exception as error:
         print_error(error)
-        print_to_intercept(NO_CELLS_FOUND)
+        utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
 
@@ -467,7 +467,7 @@ if __name__ == "__main__":
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_spatial"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_spatial"))
             sys.exit()
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
@@ -486,7 +486,7 @@ if __name__ == "__main__":
         try:
             C_new, S_new, b0_new, c0_new, g, mask = update_temporal(A, C, YrA=YrA, **params_update_temporal)
         except TypeError:
-            print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
+            utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
             sys.exit()
         # Save
         print(RUN_CNMF_SAVE_INTERMED.format("2nd"), flush=True)
@@ -501,7 +501,7 @@ if __name__ == "__main__":
 
     except Exception as error:
         print_error(error)
-        print_to_intercept(NO_CELLS_FOUND)
+        utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
     ### Save final results ###
@@ -530,9 +530,9 @@ if __name__ == "__main__":
     series = h5path_names[-2]
     sensor = h5path_names[-1]
     # Get paramaters of the operation on source data
-    params_source_data = load_attributes(file_, data+'/'+driver+'/'+operation)
+    params_source_data = utils.load_attributes(file_, data+'/'+driver+'/'+operation)
     # Get the attributes of the images stack
-    attrs = load_attributes(file_, h5path+'/ImagesStack')
+    attrs = utils.load_attributes(file_, h5path+'/ImagesStack')
     file_.close()
 
     # Parameters

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -68,7 +68,7 @@ except SyntaxError:
     utils.print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
 
-if not danse_parameters: # for backwards compatible
+if not danse_parameters: # for backwards compatibility
     danse_parameters = {"paths": kwargs , "parameters": params_doric}
 
 paths   = danse_parameters.get("paths", {})
@@ -76,7 +76,7 @@ parameters  = danse_parameters.get("parameters", {})
 
 if "tmpDir" in paths:
     dpath   = paths["tmpDir"]
-else : # for backwards compatible
+else : # for backwards compatibility
     tmpDir  = tempfile.TemporaryDirectory(prefix="minian_")
     dpath   = tmpDir.name
 

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -49,18 +49,18 @@ danse_parameters = {"file_path": kwargs , "parameters": params_doric}
 file_path   = danse_parameters.get("file_path", {})
 parameters  = danse_parameters.get("parameters", {})
 
-tmpDir = tempfile.TemporaryDirectory(prefix="minian_")
-dpath = tmpDir.name
-fr = get_frequency(file_path["fname"], file_path['h5path']+'Time')
+tmpDir  = tempfile.TemporaryDirectory(prefix="minian_")
+dpath   = tmpDir.name
+fr      = get_frequency(file_path["fname"], file_path['h5path']+'Time')
 
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 os.environ["OPENBLAS_NUM_THREADS"] = "1"
 os.environ["MINIAN_INTERMEDIATE"] = os.path.join(dpath, "intermediate")
 
-neuron_diameter             = tuple((np.array([parameters["NeuronDiameterMin"], parameters["NeuronDiameterMax"]])/parameters["SpatialDownsample"]).round().astype('int'))
-noise_freq: float           = parameters["NoiseFreq"]
-thres_corr: float           = parameters["ThresCorr"]
+neuron_diameter     = tuple((np.array([parameters["NeuronDiameterMin"], parameters["NeuronDiameterMax"]])/parameters["SpatialDownsample"]).round().astype('int'))
+noise_freq: float   = parameters["NoiseFreq"]
+thres_corr: float   = parameters["ThresCorr"]
 
 advanced_settings = parameters.get("AdvancedSettings", {})
 
@@ -68,9 +68,9 @@ advanced_settings = parameters.get("AdvancedSettings", {})
 minian_functions_list = ["TaskAnnotation", "get_optimal_chk", "custom_arr_optimize",
                          "save_minian", "open_minian", "denoise", "remove_background",
                          "seeds_init", "pnr_refine", "ks_refine", "seeds_merge", "initA", "initC",
-                        "compute_trace", "get_noise_fft", "update_spatial", "update_temporal",
-                        "unit_merge", "update_background", "compute_AtC", "apply_transform",
-                        "estimate_motion"] + ["LocalCluster"]
+                         "compute_trace", "get_noise_fft", "update_spatial", "update_temporal",
+                         "unit_merge", "update_background", "compute_AtC", "apply_transform",
+                         "estimate_motion"] + ["LocalCluster"]
 
 advanced_settings = {key: advanced_settings[key] for key in advanced_settings if key in minian_functions_list}
 
@@ -92,8 +92,8 @@ params_load_doric = {
     "h5path": file_path['h5path'],
     "dtype": np.uint8,
     "downsample": {"frame": parameters["TemporalDownsample"],
-                       "height": parameters["SpatialDownsample"],
-                       "width": parameters["SpatialDownsample"]},
+                    "height": parameters["SpatialDownsample"],
+                    "width": parameters["SpatialDownsample"]},
     "downsample_strategy": "subset",
 }
 
@@ -142,11 +142,11 @@ if "apply_transform" in advanced_settings:
 
 wnd = 60 # time window of 60 seconds
 params_seeds_init = {
-        'wnd_size': fr*wnd,
-        'method': 'rolling',
-        'stp_size': fr*wnd / 2,
-        'max_wnd': neuron_diameter[-1],
-        'diff_thres': 3
+    'wnd_size': fr*wnd,
+    'method': 'rolling',
+    'stp_size': fr*wnd / 2,
+    'max_wnd': neuron_diameter[-1],
+    'diff_thres': 3
 }
 if "seeds_init" in advanced_settings:
     params_seeds_init, advanced_settings["seeds_init"] = set_advanced_parameters_for_func_params(params_seeds_init, advanced_settings["seeds_init"], seeds_init)

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -12,16 +12,7 @@ from typing import Tuple, Optional, Callable
 from dask.distributed import Client, LocalCluster
 sys.path.append('..')
 import utilities  as utils
-from minian_utilities import (
-    load_doric_to_xarray,
-    save_minian_to_doric,
-    round_up_to_odd,
-    round_down_to_odd,
-    set_advanced_parameters_for_func_params,
-    set_advanced_parameters_for_denoise,
-    set_advanced_parameters_for_estimate_motion,
-    print_error
-)
+import minian_utilities as min_utils
 
 # Import for MiniAn lib
 from minian.utilities import TaskAnnotation, get_optimal_chk, custom_arr_optimize, save_minian, open_minian
@@ -141,15 +132,15 @@ params_get_optimal_chk = {
     "dtype": float
 }
 if "get_optimal_chk" in advanced_settings:
-    params_get_optimal_chk, advanced_settings["get_optimal_chk"] = set_advanced_parameters_for_func_params(params_get_optimal_chk, advanced_settings["get_optimal_chk"], get_optimal_chk)
+    params_get_optimal_chk, advanced_settings["get_optimal_chk"] = min_utils.set_advanced_parameters_for_func_params(params_get_optimal_chk, advanced_settings["get_optimal_chk"], get_optimal_chk)
 
 
 params_denoise = {
     'method': 'median',
-    'ksize': round_down_to_odd(neuron_diameter[-1]/2.0) # half of the maximum diameter
+    'ksize': min_utils.round_down_to_odd(neuron_diameter[-1]/2.0) # half of the maximum diameter
 }
 if "denoise" in advanced_settings:
-    params_denoise, advanced_settings["denoise"] = set_advanced_parameters_for_denoise(params_denoise, advanced_settings["denoise"], denoise)
+    params_denoise, advanced_settings["denoise"] = min_utils.set_advanced_parameters_for_denoise(params_denoise, advanced_settings["denoise"], denoise)
 
 
 params_remove_background = {
@@ -157,21 +148,21 @@ params_remove_background = {
     'wnd': np.ceil(neuron_diameter[-1]) # largest neuron diameter
 }
 if "remove_background" in advanced_settings:
-    params_remove_background, advanced_settings["remove_background"] = set_advanced_parameters_for_func_params(params_remove_background, advanced_settings["remove_background"], remove_background)
+    params_remove_background, advanced_settings["remove_background"] = min_utils.set_advanced_parameters_for_func_params(params_remove_background, advanced_settings["remove_background"], remove_background)
 
 
 params_estimate_motion = {
     'dim': 'frame'
 }
 if "estimate_motion" in advanced_settings:
-    params_estimate_motion, advanced_settings["estimate_motion"] = set_advanced_parameters_for_estimate_motion(params_estimate_motion, advanced_settings["estimate_motion"], estimate_motion)
+    params_estimate_motion, advanced_settings["estimate_motion"] = min_utils.set_advanced_parameters_for_estimate_motion(params_estimate_motion, advanced_settings["estimate_motion"], estimate_motion)
 
 
 params_apply_transform = {
     'fill': 0
 }
 if "apply_transform" in advanced_settings:
-    params_apply_transform, advanced_settings["apply_transform"] = set_advanced_parameters_for_func_params(params_apply_transform, advanced_settings["apply_transform"], apply_transform)
+    params_apply_transform, advanced_settings["apply_transform"] = min_utils.set_advanced_parameters_for_func_params(params_apply_transform, advanced_settings["apply_transform"], apply_transform)
 
 
 wnd = 60 # time window of 60 seconds
@@ -183,7 +174,7 @@ params_seeds_init = {
     'diff_thres': 3
 }
 if "seeds_init" in advanced_settings:
-    params_seeds_init, advanced_settings["seeds_init"] = set_advanced_parameters_for_func_params(params_seeds_init, advanced_settings["seeds_init"], seeds_init)
+    params_seeds_init, advanced_settings["seeds_init"] = min_utils.set_advanced_parameters_for_func_params(params_seeds_init, advanced_settings["seeds_init"], seeds_init)
 
 
 params_pnr_refine = {
@@ -191,14 +182,14 @@ params_pnr_refine = {
     "thres": 1
 }
 if "pnr_refine" in advanced_settings:
-    params_pnr_refine, advanced_settings["pnr_refine"] = set_advanced_parameters_for_func_params(params_pnr_refine, advanced_settings["pnr_refine"], pnr_refine)
+    params_pnr_refine, advanced_settings["pnr_refine"] = min_utils.set_advanced_parameters_for_func_params(params_pnr_refine, advanced_settings["pnr_refine"], pnr_refine)
 
 
 params_ks_refine = {
     "sig": 0.05
 }
 if "ks_refine" in advanced_settings:
-    params_ks_refine, advanced_settings["ks_refine"] = set_advanced_parameters_for_func_params(params_ks_refine, advanced_settings["ks_refine"], ks_refine)
+    params_ks_refine, advanced_settings["ks_refine"] = min_utils.set_advanced_parameters_for_func_params(params_ks_refine, advanced_settings["ks_refine"], ks_refine)
 
 
 params_seeds_merge = {
@@ -207,7 +198,7 @@ params_seeds_merge = {
     'noise_freq': noise_freq
 }
 if "seeds_merge" in advanced_settings:
-    params_seeds_merge, advanced_settings["seeds_merge"] = set_advanced_parameters_for_func_params(params_seeds_merge, advanced_settings["seeds_merge"], seeds_merge)
+    params_seeds_merge, advanced_settings["seeds_merge"] = min_utils.set_advanced_parameters_for_func_params(params_seeds_merge, advanced_settings["seeds_merge"], seeds_merge)
 
 
 params_initA = {
@@ -216,21 +207,21 @@ params_initA = {
     'noise_freq': noise_freq
 }
 if "initA" in advanced_settings:
-    params_initA, advanced_settings["initA"] = set_advanced_parameters_for_func_params(params_initA, advanced_settings["initA"], initA)
+    params_initA, advanced_settings["initA"] = min_utils.set_advanced_parameters_for_func_params(params_initA, advanced_settings["initA"], initA)
 
 
 params_unit_merge = {
     'thres_corr': thres_corr
 }
 if "unit_merge" in advanced_settings:
-    params_unit_merge, advanced_settings["unit_merge"] = set_advanced_parameters_for_func_params(params_unit_merge, advanced_settings["unit_merge"], unit_merge)
+    params_unit_merge, advanced_settings["unit_merge"] = min_utils.set_advanced_parameters_for_func_params(params_unit_merge, advanced_settings["unit_merge"], unit_merge)
 
 
 params_get_noise_fft = {
     'noise_range': (noise_freq, 0.5)
 }
 if "get_noise_fft" in advanced_settings:
-    params_get_noise_fft, advanced_settings["get_noise_fft"] = set_advanced_parameters_for_func_params(params_get_noise_fft, advanced_settings["get_noise_fft"], get_noise_fft)
+    params_get_noise_fft, advanced_settings["get_noise_fft"] = min_utils.set_advanced_parameters_for_func_params(params_get_noise_fft, advanced_settings["get_noise_fft"], get_noise_fft)
 
 
 params_update_spatial = {
@@ -239,7 +230,7 @@ params_update_spatial = {
     'size_thres': (np.ceil(0.9*(np.pi*neuron_diameter[0]/2)**2), np.ceil(1.1*(np.pi*neuron_diameter[-1]/2)**2))
 }
 if "update_spatial" in advanced_settings:
-    params_update_spatial, advanced_settings["update_spatial"] = set_advanced_parameters_for_func_params(params_update_spatial, advanced_settings["update_spatial"], update_spatial)
+    params_update_spatial, advanced_settings["update_spatial"] = min_utils.set_advanced_parameters_for_func_params(params_update_spatial, advanced_settings["update_spatial"], update_spatial)
 
 
 params_update_temporal = {
@@ -250,7 +241,7 @@ params_update_temporal = {
     'jac_thres': 0.2
 }
 if "update_temporal" in advanced_settings:
-    params_update_temporal, advanced_settings["update_temporal"] = set_advanced_parameters_for_func_params(params_update_temporal, advanced_settings["update_temporal"], update_temporal)
+    params_update_temporal, advanced_settings["update_temporal"] = min_utils.set_advanced_parameters_for_func_params(params_update_temporal, advanced_settings["update_temporal"], update_temporal)
 
 # Update AdvancedSettings in params_doric
 parameters["AdvancedSettings"] = advanced_settings.copy()
@@ -270,7 +261,7 @@ if __name__ == "__main__":
 
     ### Load and chunk the data ###
     print(LOAD_DATA, flush=True)
-    varr, file_ = load_doric_to_xarray(**params_load_doric)
+    varr, file_ = min_utils.load_doric_to_xarray(**params_load_doric)
     chk, _ = get_optimal_chk(varr, **params_get_optimal_chk)
     varr = save_minian(varr.chunk({"frame": chk["frame"], "height": -1, "width": -1}).rename("varr"),
                        intpath, overwrite=True)
@@ -354,7 +345,7 @@ if __name__ == "__main__":
             utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
     except Exception as error:
-        print_error(error)
+        min_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -392,7 +383,7 @@ if __name__ == "__main__":
         b = save_minian(b.rename("b"), intpath, overwrite=True)
 
     except Exception as error:
-        print_error(error)
+        min_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -455,7 +446,7 @@ if __name__ == "__main__":
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
     except Exception as error:
-        print_error(error)
+        min_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -500,7 +491,7 @@ if __name__ == "__main__":
         AC = compute_AtC(A, C_chk)
 
     except Exception as error:
-        print_error(error)
+        min_utils.print_error(error)
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -546,7 +537,7 @@ if __name__ == "__main__":
     if parameters["SpatialDownsample"] > 1:
         parameters["BinningFactor"] = parameters["SpatialDownsample"]
 
-    save_minian_to_doric(
+    min_utils.save_minian_to_doric(
         Y, A, C, AC, S,
         fr=fr,
         bits_count=attrs['BitsCount'],

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -47,13 +47,13 @@ INIT_COMP_SPATIAL           = "Initializing components: spatial..."
 INIT_COMP_TEMP              = "Initializing components: temporal..."
 INIT_COMP_MERG              = "Initializing components: merging..."
 INIT_COMP_BACKG             = "Initializing components: background..."
-RUN_CNMF_ITT                = "Running CNMF {0} itteration: "
-RUN_CNMF_ESTIM_NOISE        = RUN_CNMF_ITT + "estimating noise..."
-RUN_CNMF_UPDAT_SPATIAL      = RUN_CNMF_ITT + "updating spatial components..."
-RUN_CNMF_UPDAT_BACKG        = RUN_CNMF_ITT + "updating background components..."
-RUN_CNMF_UPDAT_TEMP         = RUN_CNMF_ITT + "updating temporal components..."
-RUN_CNMF_MERG_COMP          = RUN_CNMF_ITT + "merging components..."
-RUN_CNMF_SAVE_INTERMED      = RUN_CNMF_ITT + "saving intermediate results..."
+CNMF_IT                     = "CNMF {0} iteration"
+CNMF_ESTIM_NOISE            = CNMF_IT + ": estimating noise..."
+CNMF_UPDAT_SPATIAL          = CNMF_IT + ": updating spatial components..."
+CNMF_UPDAT_BACKG            = CNMF_IT + ": updating background components..."
+CNMF_UPDAT_TEMP             = CNMF_IT + ": updating temporal components..."
+CNMF_MERG_COMP              = CNMF_IT + ": merging components..."
+CNMF_SAVE_INTERMED          = CNMF_IT + ": saving intermediate results..."
 SAVING_FINAL                = "Saving final results..."
 SAVING_TO_DORIC             = "Saving data to doric file..."
 
@@ -398,7 +398,7 @@ if __name__ == "__main__":
     ### CNMF 1st itteration ###
     try:
         # 1. Estimate spatial noise
-        print(RUN_CNMF_ESTIM_NOISE.format("1st"), flush=True)
+        print(CNMF_ESTIM_NOISE.format("1st"), flush=True)
         try:
             sn_spatial = get_noise_fft(Y_hw_chk, **params_get_noise_fft)
         except TypeError:
@@ -406,7 +406,7 @@ if __name__ == "__main__":
             sys.exit()
         sn_spatial = save_minian(sn_spatial.rename("sn_spatial"), intpath, overwrite=True)
         # 2. First spatial update
-        print(RUN_CNMF_UPDAT_SPATIAL.format("1st"), flush=True)
+        print(CNMF_UPDAT_SPATIAL.format("1st"), flush=True)
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
@@ -415,7 +415,7 @@ if __name__ == "__main__":
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
         # 3. Update background
-        print(RUN_CNMF_UPDAT_BACKG.format("1st"), flush=True)
+        print(CNMF_UPDAT_BACKG.format("1st"), flush=True)
         b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
         A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1},)
         b = save_minian(b_new.rename("b"), intpath, overwrite=True)
@@ -423,7 +423,7 @@ if __name__ == "__main__":
         C = save_minian(C_new.rename("C"), intpath, overwrite=True)
         C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
         # 4. First temporal update
-        print(RUN_CNMF_UPDAT_TEMP.format("1st"), flush=True)
+        print(CNMF_UPDAT_TEMP.format("1st"), flush=True)
         YrA = save_minian(compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"), intpath, overwrite=True,
                         chunks={"unit_id": 1, "frame": -1})
         try:
@@ -438,14 +438,14 @@ if __name__ == "__main__":
         c0 = save_minian(c0_new.rename("c0").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         A = A.sel(unit_id=C.coords["unit_id"].values)
         # 5. Merge components
-        print(RUN_CNMF_MERG_COMP.format("1st"), flush=True)
+        print(CNMF_MERG_COMP.format("1st"), flush=True)
         try:
             A_mrg, C_mrg, [sig_mrg] = unit_merge(A, C, [C + b0 + c0], **params_unit_merge)
         except TypeError:
             utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("unit_merge"))
             sys.exit()
         # Save
-        print(RUN_CNMF_SAVE_INTERMED.format("1st"), flush=True)
+        print(CNMF_SAVE_INTERMED.format("1st"), flush=True)
         A = save_minian(A_mrg.rename("A_mrg"), intpath, overwrite=True)
         C = save_minian(C_mrg.rename("C_mrg"), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_mrg_chk"), intpath, overwrite=True,
@@ -453,7 +453,7 @@ if __name__ == "__main__":
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
     except Exception as error:
-        utils.print_error(error, RUN_CNMF_ITT.format("1st"))
+        utils.print_error(error, CNMF_IT.format("1st"))
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -461,7 +461,7 @@ if __name__ == "__main__":
     ### CNMF 2nd itteration ###
     try:
         # 5. Second spatial update
-        print(RUN_CNMF_UPDAT_SPATIAL.format("2nd"), flush=True)
+        print(CNMF_UPDAT_SPATIAL.format("2nd"), flush=True)
         try:
             A_new, mask, norm_fac = update_spatial(Y_hw_chk, A, C, sn_spatial, **params_update_spatial)
         except TypeError:
@@ -470,7 +470,7 @@ if __name__ == "__main__":
         C_new = save_minian((C.sel(unit_id=mask) * norm_fac).rename("C_new"), intpath, overwrite=True)
         C_chk_new = save_minian((C_chk.sel(unit_id=mask) * norm_fac).rename("C_chk_new"), intpath, overwrite=True)
         # 6. Second background update
-        print(RUN_CNMF_UPDAT_BACKG.format("2nd"), flush=True)
+        print(CNMF_UPDAT_BACKG.format("2nd"), flush=True)
         b_new, f_new = update_background(Y_fm_chk, A_new, C_chk_new)
         A = save_minian(A_new.rename("A"), intpath, overwrite=True, chunks={"unit_id": 1, "height": -1, "width": -1},)
         b = save_minian(b_new.rename("b"), intpath, overwrite=True)
@@ -478,7 +478,7 @@ if __name__ == "__main__":
         C = save_minian(C_new.rename("C"), intpath, overwrite=True)
         C_chk = save_minian(C_chk_new.rename("C_chk"), intpath, overwrite=True)
         # 7. Second temporal update
-        print(RUN_CNMF_UPDAT_TEMP.format("2nd"), flush=True)
+        print(CNMF_UPDAT_TEMP.format("2nd"), flush=True)
         YrA = save_minian(compute_trace(Y_fm_chk, A, b, C_chk, f).rename("YrA"), intpath, overwrite=True,
                         chunks={"unit_id": 1, "frame": -1})
         try:
@@ -487,7 +487,7 @@ if __name__ == "__main__":
             utils.print_to_intercept(ONE_PARM_WRONG_TYPE.format("update_temporal"))
             sys.exit()
         # Save
-        print(RUN_CNMF_SAVE_INTERMED.format("2nd"), flush=True)
+        print(CNMF_SAVE_INTERMED.format("2nd"), flush=True)
         C = save_minian(C_new.rename("C").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
         C_chk = save_minian(C.rename("C_chk"), intpath, overwrite=True, chunks={"unit_id": -1, "frame": chk["frame"]})
         S = save_minian(S_new.rename("S").chunk({"unit_id": 1, "frame": -1}), intpath, overwrite=True)
@@ -498,7 +498,7 @@ if __name__ == "__main__":
         AC = compute_AtC(A, C_chk)
 
     except Exception as error:
-        utils.print_error(error, RUN_CNMF_ITT.format("2nd"))
+        utils.print_error(error, CNMF_IT.format("2nd"))
         utils.print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -68,15 +68,19 @@ except SyntaxError:
     utils.print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
 
-if not danse_parameters:
-    danse_parameters = {"file_path": kwargs , "parameters": params_doric}
+if not danse_parameters: # for backwards compatible
+    danse_parameters = {"paths": kwargs , "parameters": params_doric}
 
-file_path   = danse_parameters.get("file_path", {})
+paths   = danse_parameters.get("paths", {})
 parameters  = danse_parameters.get("parameters", {})
 
-tmpDir  = tempfile.TemporaryDirectory(prefix="minian_")
-dpath   = tmpDir.name
-fr      = utils.get_frequency(file_path["fname"], file_path['h5path']+'Time')
+if "tmpDir" in paths:
+    dpath   = paths["tmpDir"]
+else : # for backwards compatible
+    tmpDir  = tempfile.TemporaryDirectory(prefix="minian_")
+    dpath   = tmpDir.name
+
+fr      = utils.get_frequency(paths["fname"], paths['h5path']+'Time')
 
 os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
@@ -113,8 +117,8 @@ if "LocalCluster" in advanced_settings:
 
 
 params_load_doric = {
-    "fname": file_path["fname"],
-    "h5path": file_path['h5path'],
+    "fname": paths["fname"],
+    "h5path": paths['h5path'],
     "dtype": np.uint8,
     "downsample": {"frame": parameters["TemporalDownsample"],
                     "height": parameters["SpatialDownsample"],

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -67,6 +67,9 @@ try:
 except SyntaxError:
     utils.print_to_intercept(ADVANCED_BAD_TYPE)
     sys.exit()
+except Exception as error:
+    min_utils.print_error(error)
+    sys.exit()
 
 if not danse_parameters: # for backwards compatibility
     danse_parameters = {"paths": kwargs , "parameters": params_doric}

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -19,7 +19,8 @@ from minian_utilities import (
     round_down_to_odd,
     set_advanced_parameters_for_func_params,
     set_advanced_parameters_for_denoise,
-    set_advanced_parameters_for_estimate_motion
+    set_advanced_parameters_for_estimate_motion,
+    print_error
 )
 
 # Import for MiniAn lib
@@ -353,7 +354,7 @@ if __name__ == "__main__":
             print_to_intercept(ONE_PARM_WRONG_TYPE.format("seeds_merge"))
             sys.exit()
     except Exception as error:
-        print("An error occurred:", type(error).__name__, "-", error, flush=True)
+        print_error(error)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -391,7 +392,7 @@ if __name__ == "__main__":
         b = save_minian(b.rename("b"), intpath, overwrite=True)
 
     except Exception as error:
-        print("An error occurred:", type(error).__name__, "-", error, flush=True)
+        print_error(error)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -454,7 +455,7 @@ if __name__ == "__main__":
         sig = save_minian(sig_mrg.rename("sig_mrg"), intpath, overwrite=True)
 
     except Exception as error:
-        print("An error occurred:", type(error).__name__, "-", error, flush=True)
+        print_error(error)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 
@@ -499,7 +500,7 @@ if __name__ == "__main__":
         AC = compute_AtC(A, C_chk)
 
     except Exception as error:
-        print("An error occurred:", type(error).__name__, "-", error, flush=True)
+        print_error(error)
         print_to_intercept(NO_CELLS_FOUND)
         sys.exit()
 

--- a/MiniAn/minian_utilities.py
+++ b/MiniAn/minian_utilities.py
@@ -10,16 +10,7 @@ from typing import Optional, Callable
 from minian.utilities import custom_arr_optimize
 sys.path.append('..')
 
-from utilities import (
-    save_roi_signals,
-    save_signals,
-    save_images,
-    load_attributes,
-    save_attributes,
-    print_group_path_for_DANSE,
-    print_to_intercept,
-    merge_params,
-)
+import utilities as utils
 
 def load_doric_to_xarray(
     fname: str,
@@ -182,8 +173,8 @@ def save_minian_to_doric(
             if len(operations) > 0:
                 operationCount = str(len(operations))
                 for operation in operations:
-                    operationAttrs = load_attributes(f, vpath+operation)
-                    if merge_params(params_doric, params_source) == operationAttrs:
+                    operationAttrs = utils.load_attributes(f, vpath+operation)
+                    if utils.merge_params(params_doric, params_source) == operationAttrs:
                         if(len(operation) == len(ROISIGNALS)):
                             operationCount = ''
                         else:
@@ -202,30 +193,30 @@ def save_minian_to_doric(
 
         print("saving ROI signals")
         pathROIs = vpath+ROISIGNALS+operationCount+'/'
-        save_roi_signals(C.values, A.values, time_, f, pathROIs+vdataset, attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
-        print_group_path_for_DANSE(pathROIs+vdataset)
-        save_attributes(merge_params(params_doric, params_source), f, pathROIs)
+        utils.save_roi_signals(C.values, A.values, time_, f, pathROIs+vdataset, attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
+        utils.print_group_path_for_DANSE(pathROIs+vdataset)
+        utils.save_attributes(utils.merge_params(params_doric, params_source), f, pathROIs)
 
         if saveimages:
             print("saving images")
             pathImages = vpath+IMAGES+operationCount+'/'
-            save_images(AC.values, time_, f, pathImages+vdataset, bits_count=bits_count, qt_format=qt_format, username=imagesStackUsername)
-            print_group_path_for_DANSE(pathImages+vdataset)
-            save_attributes(merge_params(params_doric, params_source, params_doric["Operations"] + "(Images)"), f, pathImages)
+            utils.save_images(AC.values, time_, f, pathImages+vdataset, bits_count=bits_count, qt_format=qt_format, username=imagesStackUsername)
+            utils.print_group_path_for_DANSE(pathImages+vdataset)
+            utils.save_attributes(utils.merge_params(params_doric, params_source, params_doric["Operations"] + "(Images)"), f, pathImages)
 
         if saveresiduals:
             print("saving residual images")
             pathResiduals = vpath+RESIDUALS+operationCount+'/'
-            save_images(res.values, time_, f, pathResiduals+vdataset, bits_count=bits_count, qt_format=qt_format, username=imagesStackUsername)
-            print_group_path_for_DANSE(pathResiduals+vdataset)
-            save_attributes(merge_params(params_doric, params_source,  params_doric["Operations"] + "(Residuals)"), f, pathResiduals)
+            utils.save_images(res.values, time_, f, pathResiduals+vdataset, bits_count=bits_count, qt_format=qt_format, username=imagesStackUsername)
+            utils.print_group_path_for_DANSE(pathResiduals+vdataset)
+            utils.save_attributes(utils.merge_params(params_doric, params_source,  params_doric["Operations"] + "(Residuals)"), f, pathResiduals)
 
         if savespikes:
             print("saving spikes")
             pathSpikes = vpath+SPIKES+operationCount+'/'
-            save_signals(S.values > 0, time_, f, pathSpikes+vdataset, names, usernames, range_min=0, range_max=1)
-            print_group_path_for_DANSE(pathSpikes+vdataset)
-            save_attributes(merge_params(params_doric, params_source), f, pathSpikes)
+            utils.save_signals(S.values > 0, time_, f, pathSpikes+vdataset, names, usernames, range_min=0, range_max=1)
+            utils.print_group_path_for_DANSE(pathSpikes+vdataset)
+            utils.save_attributes(utils.merge_params(params_doric, params_source), f, pathSpikes)
 
     print("Saved to {}".format(vname))
 

--- a/MiniAn/minian_utilities.py
+++ b/MiniAn/minian_utilities.py
@@ -334,6 +334,3 @@ def set_advanced_parameters_for_estimate_motion(
         advanced_parameters[key] = value
 
     return [param_func, advanced_parameters]
-
-def print_error(error):
-    print("An error occurred:", type(error).__name__, "-", error, flush=True)

--- a/MiniAn/minian_utilities.py
+++ b/MiniAn/minian_utilities.py
@@ -343,3 +343,6 @@ def set_advanced_parameters_for_estimate_motion(
         advanced_parameters[key] = value
 
     return [param_func, advanced_parameters]
+
+def print_error(error):
+    print("An error occurred:", type(error).__name__, "-", error, flush=True)


### PR DESCRIPTION
- fixing bug with typo when using variables for text (typo was f**ro**mat() and it should be f**or**mat() )
- adding print to show what type of error when try: except: "no cells where found"  is trigger
-  Us `import utilities as utils` and `import minian_utilities as min_utils`  (things I thought I did...)