### PR TITLE
Fix chunk size when saving signals

### DIFF
--- a/Deploy/pack_minian_run.spec
+++ b/Deploy/pack_minian_run.spec
@@ -10,9 +10,10 @@ from PyInstaller.utils.hooks import collect_dynamic_libs
 
 block_cipher = None
 
-datas = []
-binaries = []
-hiddenimports = []
+datas           = []
+binaries        = []
+hiddenimports   = []
+excludes        = []
 
 tmp_ret = collect_all('minian')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
@@ -21,6 +22,8 @@ tmp_ret = collect_all('distributed')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 
 binaries += collect_dynamic_libs('llvmlite',destdir='.\\Library\\bin')
+
+excludes = ["IPython", "matplotlib", "PyQt5", "Markdown", "jupyter"]
 
 a_minian = Analysis(
     ['../MiniAn/minian_run.py'],
@@ -31,7 +34,7 @@ a_minian = Analysis(
     hookspath=[],
     hooksconfig={},
     runtime_hooks=[],
-    excludes=[],
+    excludes=excludes,
     win_no_prefer_redirects=False,
     win_private_assemblies=False,
     cipher=block_cipher,

--- a/utilities.py
+++ b/utilities.py
@@ -123,7 +123,7 @@ def get_dims(
 
     return shape[:-1], shape[-1]
 
-
+#*************************************************************** SAVE FUNCTIONS ********************************************
 def save_images(
     images: np.ndarray,
     time_: np.array,
@@ -348,7 +348,7 @@ def footprint_to_coords(
 
     return coords
 
-
+#*************************************************************** PARAMETER FUNCTIONS ********************************************
 def merge_params(
     params_current,
     params_source = {},
@@ -417,7 +417,7 @@ def create_params_item(
 
     return {key_final: value_final}
 
-
+#*************************************************************** PRINT FUNCTIONS ********************************************
 def print_to_intercept(msg):
     if not isinstance(msg, str):
         msg = str(msg)
@@ -434,3 +434,5 @@ def print_group_path_for_DANSE(path):
 
 def print_error(error, position):
     print(defs.Messages.ERROR_IN.format(position = position, type_error_name = type(error).__name__, error = error), flush=True)
+
+#*************************************************************** OTHER FUNCTIONS ********************************************

--- a/utilities.py
+++ b/utilities.py
@@ -7,6 +7,8 @@ from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 
 import definitions as defs
 
+CHUNK_SIZE = 65536
+
 def load_attributes(
     file_: Union[h5py.File, str],
     path: str = ""
@@ -158,22 +160,19 @@ def save_images(
     height = images.shape[1]
     width = images.shape[2]
 
-    try:
-        dataset = f.create_dataset(path+defs.DoricFile.Dataset.IMAGE_STACK, (height,width,duration), dtype="uint16",
-                                  chunks=(height,width,1), maxshape=(height,width,None))
-    except:
+    if path+defs.DoricFile.Dataset.IMAGE_STACK in f:
         del f[path+defs.DoricFile.Dataset.IMAGE_STACK]
-        dataset = f.create_dataset(path+defs.DoricFile.Dataset.IMAGE_STACK, (height,width,duration), dtype="uint16",
+
+    dataset = f.create_dataset(path+defs.DoricFile.Dataset.IMAGE_STACK, (height,width,duration), dtype="uint16",
                                   chunks=(height,width,1), maxshape=(height,width,None))
 
     for i, image in enumerate(images):
         dataset[:,:,i] = image
 
-    try:
-        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=True, maxshape=None)
-    except:
+    if path+defs.DoricFile.Dataset.TIME in f:
         del f[path+defs.DoricFile.Dataset.TIME]
-        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=True, maxshape=None)
+
+    f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
 
     f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
     f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
@@ -262,11 +261,10 @@ def save_signal(
     attrs: Optional[dict] = None
     ):
 
-    try:
-        f.create_dataset(path, data=signal, dtype="float64", chunks=True, maxshape=None)
-    except:
+    if path in f:
         del f[path]
-        f.create_dataset(path, data=signal, dtype="float64", chunks=True, maxshape=None)
+
+    f.create_dataset(path, data=signal, dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
 
 
     if attrs is not None:
@@ -293,16 +291,16 @@ def save_signals(
         path += '/'
 
     try:
-        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=True, maxshape=None)
+        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
     except:
         pass
 
     for i,name in enumerate(names):
-        try:
-            f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=True, maxshape=None)
-        except:
+
+        if path+name in f:
             del f[path+name]
-            f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=True, maxshape=None)
+
+        f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
 
         attrs = {}
 

--- a/utilities.py
+++ b/utilities.py
@@ -7,8 +7,6 @@ from typing import Any, Dict, List, Optional, Tuple, Union, Callable
 
 import definitions as defs
 
-CHUNK_SIZE = 65536
-
 def load_attributes(
     file_: Union[h5py.File, str],
     path: str = ""
@@ -172,7 +170,7 @@ def save_images(
     if path+defs.DoricFile.Dataset.TIME in f:
         del f[path+defs.DoricFile.Dataset.TIME]
 
-    f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
+    f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_), maxshape=None)
 
     f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
     f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
@@ -264,7 +262,7 @@ def save_signal(
     if path in f:
         del f[path]
 
-    f.create_dataset(path, data=signal, dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
+    f.create_dataset(path, data=signal, dtype="float64", chunks=def_chunk_size(signal), maxshape=None)
 
 
     if attrs is not None:
@@ -291,7 +289,7 @@ def save_signals(
         path += '/'
 
     try:
-        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
+        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_), maxshape=None)
     except:
         pass
 
@@ -300,7 +298,7 @@ def save_signals(
         if path+name in f:
             del f[path+name]
 
-        f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=CHUNK_SIZE, maxshape=None)
+        f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=def_chunk_size(signals[i]), maxshape=None)
 
         attrs = {}
 
@@ -436,3 +434,18 @@ def print_error(error, position):
     print(defs.Messages.ERROR_IN.format(position = position, type_error_name = type(error).__name__, error = error), flush=True)
 
 #*************************************************************** OTHER FUNCTIONS ********************************************
+def def_chunk_size(data):
+    if data.ndim == 3:
+        height   = data.shape[1]
+        width    = data.shape[2]
+
+        return (height,width,1)
+
+    if data.ndim == 1:
+        chunk_size = 65536
+        durantion = data.shape[0]
+
+        if durantion < chunk_size:
+            chunk_size = durantion
+
+        return  chunk_size

--- a/utilities.py
+++ b/utilities.py
@@ -170,7 +170,7 @@ def save_images(
     if path+defs.DoricFile.Dataset.TIME in f:
         del f[path+defs.DoricFile.Dataset.TIME]
 
-    f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_), maxshape=None)
+    f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_.shape), maxshape=None)
 
     f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
     f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
@@ -262,7 +262,7 @@ def save_signal(
     if path in f:
         del f[path]
 
-    f.create_dataset(path, data=signal, dtype="float64", chunks=def_chunk_size(signal), maxshape=None)
+    f.create_dataset(path, data=signal, dtype="float64", chunks=def_chunk_size(signal.shape), maxshape=None)
 
 
     if attrs is not None:
@@ -289,7 +289,7 @@ def save_signals(
         path += '/'
 
     try:
-        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_), maxshape=None)
+        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_.shape), maxshape=None)
     except:
         pass
 
@@ -298,7 +298,7 @@ def save_signals(
         if path+name in f:
             del f[path+name]
 
-        f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=def_chunk_size(signals[i]), maxshape=None)
+        f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=def_chunk_size(signals[i].shape), maxshape=None)
 
         attrs = {}
 
@@ -434,16 +434,17 @@ def print_error(error, position):
     print(defs.Messages.ERROR_IN.format(position = position, type_error_name = type(error).__name__, error = error), flush=True)
 
 #*************************************************************** OTHER FUNCTIONS ********************************************
-def def_chunk_size(data):
-    if data.ndim == 3:
-        height   = data.shape[1]
-        width    = data.shape[2]
+def def_chunk_size(data_shape):
+
+    if len(data_shape) == 3:
+        height   = data_shape[1]
+        width    = data_shape[2]
 
         return (height,width,1)
 
-    if data.ndim == 1:
+    if len(data_shape) == 1:
         chunk_size = 65536
-        durantion = data.shape[0]
+        durantion = data_shape[0]
 
         if durantion < chunk_size:
             chunk_size = durantion


### PR DESCRIPTION
- Fix chunk size to 65536 or signal size if signal size less than 65536
- Edit .spec to exclude python package that are not used by MiniAn