### PR TITLE
Reworking paths

### DIFF
--- a/MiniAn/minian_definitions.py
+++ b/MiniAn/minian_definitions.py
@@ -48,6 +48,8 @@ class Messages:
     ADVANCED_BAD_TYPE           = "One of the advanced parameters is not of a python type"
     LOADING_ARGUMENTS           = "Loading parameters"
 
+    PROCESS_DONE                = "MiniAn process is done"
+
     """
     Cross Registration
     """

--- a/MiniAn/minian_main.py
+++ b/MiniAn/minian_main.py
@@ -569,7 +569,7 @@ def save_minian_to_doric(
         params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] += operationCount
 
         print(mn_defs.Messages.SAVE_ROI_SIG, flush=True)
-        pathROIs          = '/'.join([vpath, mn_defs.DoricFile.Group.ROISIGNALS, operationCount])
+        pathROIs          = f"{vpath}/{mn_defs.DoricFile.Group.ROISIGNALS+operationCount}"
         pathROIs_vdataset = f"{pathROIs}/{vdataset}"
         utils.save_roi_signals(C.values, A.values, time_, f, pathROIs_vdataset, attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
         utils.print_group_path_for_DANSE(pathROIs_vdataset)
@@ -577,23 +577,23 @@ def save_minian_to_doric(
 
         if saveimages:
             print(mn_defs.Messages.SAVE_IMAGES, flush=True)
-            pathImages          = '/'.join([vpath, mn_defs.DoricFile.Group.IMAGES, operationCount])
+            pathImages          = f"{vpath}/{mn_defs.DoricFile.Group.IMAGES+operationCount}"
             pathImages_vdataset = f"{pathImages}/{vdataset}"
-            utils.save_images(AC.values, time_, f,pathImages_vdataset , bit_count=bit_count, qt_format=qt_format, username=username)
+            utils.save_images(AC.values, time_, f, pathImages_vdataset, bit_count=bit_count, qt_format=qt_format, username=username)
             utils.print_group_path_for_DANSE(pathImages_vdataset)
             utils.save_attributes(utils.merge_params(params_doric, params_source, params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Images)"), f, pathImages)
 
         if saveresiduals:
             print(mn_defs.Messages.SAVE_RES_IMAGES, flush=True)
-            pathResiduals          = '/'.join([vpath, mn_defs.DoricFile.Group.RESIDUALS, operationCount])
+            pathResiduals          = f"{vpath}/{mn_defs.DoricFile.Group.RESIDUALS+operationCount}"
             pathResiduals_vdataset = f"{pathResiduals}/{vdataset}"
-            utils.save_images(res.values, time_, f,pathResiduals_vdataset , bit_count=bit_count, qt_format=qt_format, username=username)
+            utils.save_images(res.values, time_, f, pathResiduals_vdataset, bit_count=bit_count, qt_format=qt_format, username=username)
             utils.print_group_path_for_DANSE(pathResiduals_vdataset)
             utils.save_attributes(utils.merge_params(params_doric, params_source,  params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Residuals)"), f, pathResiduals)
 
         if savespikes:
             print(mn_defs.Messages.SAVE_SPIKES, flush=True)
-            pathSpikes          = '/'.join([vpath, mn_defs.DoricFile.Group.SPIKES, operationCount])
+            pathSpikes          = f"{vpath}/{mn_defs.DoricFile.Group.SPIKES+operationCount}"
             pathSpikes_vdataset = f"{pathSpikes}/{vdataset}"
             utils.save_signals(S.values > 0, time_, f, pathSpikes_vdataset, names, usernames, range_min=0, range_max=1)
             utils.print_group_path_for_DANSE(pathSpikes_vdataset)

--- a/MiniAn/minian_main.py
+++ b/MiniAn/minian_main.py
@@ -570,35 +570,35 @@ def save_minian_to_doric(
         params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] += operationCount
 
         print(mn_defs.Messages.SAVE_ROI_SIG, flush=True)
-        pathROIs          = f"{vpath}/{mn_defs.DoricFile.Group.ROISIGNALS+operationCount}"
-        pathROIs_vdataset = f"{pathROIs}/{vdataset}"
-        utils.save_roi_signals(C.values, A.values, time_, f, pathROIs_vdataset, attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
-        utils.print_group_path_for_DANSE(pathROIs_vdataset)
-        utils.save_attributes(utils.merge_params(params_doric, params_source), f, pathROIs)
+        rois_grouppath = f"{vpath}/{mn_defs.DoricFile.Group.ROISIGNALS+operationCount}"
+        rois_datapath  = f"{rois_grouppath}/{vdataset}"
+        utils.save_roi_signals(C.values, A.values, time_, f, rois_datapath, attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
+        utils.print_group_path_for_DANSE(rois_datapath)
+        utils.save_attributes(utils.merge_params(params_doric, params_source), f, rois_grouppath)
 
         if saveimages:
             print(mn_defs.Messages.SAVE_IMAGES, flush=True)
-            pathImages          = f"{vpath}/{mn_defs.DoricFile.Group.IMAGES+operationCount}"
-            pathImages_vdataset = f"{pathImages}/{vdataset}"
-            utils.save_images(AC.values, time_, f, pathImages_vdataset, bit_count=bit_count, qt_format=qt_format, username=username)
-            utils.print_group_path_for_DANSE(pathImages_vdataset)
-            utils.save_attributes(utils.merge_params(params_doric, params_source, params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Images)"), f, pathImages)
+            images_grouppath = f"{vpath}/{mn_defs.DoricFile.Group.IMAGES+operationCount}"
+            images_datapath  = f"{images_grouppath}/{vdataset}"
+            utils.save_images(AC.values, time_, f, images_datapath, bit_count=bit_count, qt_format=qt_format, username=username)
+            utils.print_group_path_for_DANSE(images_datapath)
+            utils.save_attributes(utils.merge_params(params_doric, params_source, params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Images)"), f, images_grouppath)
 
         if saveresiduals:
             print(mn_defs.Messages.SAVE_RES_IMAGES, flush=True)
-            pathResiduals          = f"{vpath}/{mn_defs.DoricFile.Group.RESIDUALS+operationCount}"
-            pathResiduals_vdataset = f"{pathResiduals}/{vdataset}"
-            utils.save_images(res.values, time_, f, pathResiduals_vdataset, bit_count=bit_count, qt_format=qt_format, username=username)
-            utils.print_group_path_for_DANSE(pathResiduals_vdataset)
-            utils.save_attributes(utils.merge_params(params_doric, params_source,  params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Residuals)"), f, pathResiduals)
+            residuals_grouppath = f"{vpath}/{mn_defs.DoricFile.Group.RESIDUALS+operationCount}"
+            residuals_datapath  = f"{residuals_grouppath}/{vdataset}"
+            utils.save_images(res.values, time_, f, residuals_datapath, bit_count=bit_count, qt_format=qt_format, username=username)
+            utils.print_group_path_for_DANSE(residuals_datapath)
+            utils.save_attributes(utils.merge_params(params_doric, params_source,  params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Residuals)"), f, residuals_grouppath)
 
         if savespikes:
             print(mn_defs.Messages.SAVE_SPIKES, flush=True)
-            pathSpikes          = f"{vpath}/{mn_defs.DoricFile.Group.SPIKES+operationCount}"
-            pathSpikes_vdataset = f"{pathSpikes}/{vdataset}"
-            utils.save_signals(S.values > 0, time_, f, pathSpikes_vdataset, names, usernames, range_min=0, range_max=1)
-            utils.print_group_path_for_DANSE(pathSpikes_vdataset)
-            utils.save_attributes(utils.merge_params(params_doric, params_source), f, pathSpikes)
+            spikes_grouppath = f"{vpath}/{mn_defs.DoricFile.Group.SPIKES+operationCount}"
+            spikes_datapath  = f"{spikes_grouppath}/{vdataset}"
+            utils.save_signals(S.values > 0, time_, f, spikes_datapath, names, usernames, range_min=0, range_max=1)
+            utils.print_group_path_for_DANSE(spikes_datapath)
+            utils.save_attributes(utils.merge_params(params_doric, params_source), f, spikes_grouppath)
 
     print(mn_defs.Messages.SAVE_TO.format(path = vname))
 

--- a/MiniAn/minian_main.py
+++ b/MiniAn/minian_main.py
@@ -177,6 +177,8 @@ def preview(minian_parameters):
     client.close()
     cluster.close()
 
+    print(mn_defs.Messages.PROCESS_DONE, flush=True)
+
 
 def load_chunk(intpath, subset, minian_parameters):
 

--- a/MiniAn/minian_main.py
+++ b/MiniAn/minian_main.py
@@ -536,8 +536,8 @@ def save_minian_to_doric(
         Absolute path of the resulting video.
     """
 
-    vpath    = utils.clean_path(vpath) + '/'
-    vdataset = utils.clean_path(vdataset) + '/'
+    vpath    = utils.clean_path(vpath)
+    vdataset = utils.clean_path(vdataset)
 
     res = Y - AC # residual images
 
@@ -569,30 +569,34 @@ def save_minian_to_doric(
         params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] += operationCount
 
         print(mn_defs.Messages.SAVE_ROI_SIG, flush=True)
-        pathROIs = '/'.join([vpath, mn_defs.DoricFile.Group.ROISIGNALS, operationCount])
-        utils.save_roi_signals(C.values, A.values, time_, f, f"{pathROIs}/{vdataset}", attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
-        utils.print_group_path_for_DANSE(f"{pathROIs}/{vdataset}")
+        pathROIs          = '/'.join([vpath, mn_defs.DoricFile.Group.ROISIGNALS, operationCount])
+        pathROIs_vdataset = f"{pathROIs}/{vdataset}"
+        utils.save_roi_signals(C.values, A.values, time_, f, pathROIs_vdataset, attrs_add={"RangeMin": 0, "RangeMax": 0, "Unit": "AU"})
+        utils.print_group_path_for_DANSE(pathROIs_vdataset)
         utils.save_attributes(utils.merge_params(params_doric, params_source), f, pathROIs)
 
         if saveimages:
             print(mn_defs.Messages.SAVE_IMAGES, flush=True)
-            pathImages = '/'.join([vpath, mn_defs.DoricFile.Group.IMAGES, operationCount])
-            utils.save_images(AC.values, time_, f, f"{pathImages}/{vdataset}", bit_count=bit_count, qt_format=qt_format, username=username)
-            utils.print_group_path_for_DANSE(f"{pathImages}/{vdataset}")
+            pathImages          = '/'.join([vpath, mn_defs.DoricFile.Group.IMAGES, operationCount])
+            pathImages_vdataset = f"{pathImages}/{vdataset}"
+            utils.save_images(AC.values, time_, f,pathImages_vdataset , bit_count=bit_count, qt_format=qt_format, username=username)
+            utils.print_group_path_for_DANSE(pathImages_vdataset)
             utils.save_attributes(utils.merge_params(params_doric, params_source, params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Images)"), f, pathImages)
 
         if saveresiduals:
             print(mn_defs.Messages.SAVE_RES_IMAGES, flush=True)
-            pathResiduals = '/'.join([vpath, mn_defs.DoricFile.Group.RESIDUALS, operationCount])
-            utils.save_images(res.values, time_, f, f"{pathResiduals}/{vdataset}", bit_count=bit_count, qt_format=qt_format, username=username)
-            utils.print_group_path_for_DANSE(f"{pathResiduals}/{vdataset}")
+            pathResiduals          = '/'.join([vpath, mn_defs.DoricFile.Group.RESIDUALS, operationCount])
+            pathResiduals_vdataset = f"{pathResiduals}/{vdataset}"
+            utils.save_images(res.values, time_, f,pathResiduals_vdataset , bit_count=bit_count, qt_format=qt_format, username=username)
+            utils.print_group_path_for_DANSE(pathResiduals_vdataset)
             utils.save_attributes(utils.merge_params(params_doric, params_source,  params_doric[defs.DoricFile.Attribute.Group.OPERATIONS] + "(Residuals)"), f, pathResiduals)
 
         if savespikes:
             print(mn_defs.Messages.SAVE_SPIKES, flush=True)
-            pathSpikes = '/'.join([vpath, mn_defs.DoricFile.Group.SPIKES, operationCount])
-            utils.save_signals(S.values > 0, time_, f, f"{pathSpikes}/{vdataset}", names, usernames, range_min=0, range_max=1)
-            utils.print_group_path_for_DANSE(f"{pathSpikes}/{vdataset}")
+            pathSpikes          = '/'.join([vpath, mn_defs.DoricFile.Group.SPIKES, operationCount])
+            pathSpikes_vdataset = f"{pathSpikes}/{vdataset}"
+            utils.save_signals(S.values > 0, time_, f, pathSpikes_vdataset, names, usernames, range_min=0, range_max=1)
+            utils.print_group_path_for_DANSE(pathSpikes_vdataset)
             utils.save_attributes(utils.merge_params(params_doric, params_source), f, pathSpikes)
 
     print(mn_defs.Messages.SAVE_TO.format(path = vname))

--- a/MiniAn/minian_main.py
+++ b/MiniAn/minian_main.py
@@ -177,7 +177,6 @@ def preview(minian_parameters):
     client.close()
     cluster.close()
 
-    print(mn_defs.Messages.PROCESS_DONE, flush=True)
 
 
 def load_chunk(intpath, subset, minian_parameters):

--- a/MiniAn/minian_parameters.py
+++ b/MiniAn/minian_parameters.py
@@ -25,6 +25,8 @@ class MinianParameters:
         self.paths   = danse_parameters.get(defs.Parameters.Main.PATHS, {})
         self.parameters  = danse_parameters.get(defs.Parameters.Main.PARAMETERS, {})
 
+        self.paths[defs.Parameters.Path.H5PATH] = utils.clean_path(self.paths[defs.Parameters.Path.H5PATH])
+
         self.preview = False
         if defs.Parameters.Main.PREVIEW in danse_parameters:
             self.preview = True
@@ -35,7 +37,7 @@ class MinianParameters:
         os.environ["OPENBLAS_NUM_THREADS"]  = "1"
         os.environ["MINIAN_INTERMEDIATE"]   = os.path.join(self.paths[defs.Parameters.Path.TMP_DIR], mn_defs.Folder.INTERMEDIATE)
 
-        self.freq = utils.get_frequency(self.paths[defs.Parameters.Path.FILEPATH], self.paths[defs.Parameters.Path.H5PATH] + defs.DoricFile.Dataset.TIME)
+        self.freq = utils.get_frequency(self.paths[defs.Parameters.Path.FILEPATH], f"{self.paths[defs.Parameters.Path.H5PATH]}/{defs.DoricFile.Dataset.TIME}")
 
         neuron_diameter = np.array([self.parameters[defs.Parameters.danse.NEURO_DIAM_MIN], self.parameters[defs.Parameters.danse.NEURO_DIAM_MAX]])
         neuron_diameter = neuron_diameter / self.parameters[defs.Parameters.danse.SPATIAL_DOWNSAMPLE]
@@ -286,29 +288,13 @@ class MinianParameters:
         return [all_params, advanced_params]
 
 
-    def clean_h5path(self):
-
-        """
-        Correct the path for hdf5 file
-        """
-
-        h5path = self.paths[defs.Parameters.Path.H5PATH]
-
-        if h5path[0] == '/':
-            h5path = h5path[1:]
-        if h5path[-1] == '/':
-            h5path = h5path[:-1]
-
-        return h5path
-
-
     def get_h5path_names(self):
 
         """
         Split the path to dataset into relevant names
         """
 
-        h5path_names = self.clean_h5path().split('/')
+        h5path_names = self.paths[defs.Parameters.Path.H5PATH].split('/')
 
         data = h5path_names[0]
         driver = h5path_names[1]

--- a/MiniAn/minian_run.py
+++ b/MiniAn/minian_run.py
@@ -40,3 +40,5 @@ if __name__ == "__main__":
         mn_main.preview(minian_params)
     else:
         mn_main.main(minian_params)
+
+    print(mn_defs.Messages.PROCESS_DONE, flush=True)

--- a/utilities.py
+++ b/utilities.py
@@ -28,6 +28,8 @@ def load_attributes(
         KeyError: If path does not exist in the file
     """
 
+    path = clean_path(path)
+
     if type(file_) != h5py.File:
         if not h5py.is_hdf5(file_):
             raise TypeError(defs.Messages.F_NOT_H5_FILE_FILEPATH)
@@ -99,6 +101,8 @@ def get_dims(
     file_: Union[h5py.File, str],
     path: str
     ) -> Tuple[Tuple[int, int], int]:
+
+    path = clean_path(path)
 
     if type(file_) != h5py.File:
         if not h5py.is_hdf5(file_):
@@ -320,6 +324,7 @@ def save_attributes(
     f: h5py.File,
     path: str
     ):
+    path = clean_path(path)
 
     for key in attributes.keys():
         try:

--- a/utilities.py
+++ b/utilities.py
@@ -450,3 +450,13 @@ def def_chunk_size(data_shape):
             chunk_size = durantion
 
         return  chunk_size
+
+
+def clean_path(path):
+
+    if path[0] == '/':
+        path = path[1:]
+    if path[-1] == '/':
+        path = path[:-1]
+
+    return path

--- a/utilities.py
+++ b/utilities.py
@@ -462,6 +462,7 @@ def clean_path(path):
 
     if path[0] == '/':
         path = path[1:]
+
     if path[-1] == '/':
         path = path[:-1]
 

--- a/utilities.py
+++ b/utilities.py
@@ -157,30 +157,33 @@ def save_images(
         username: Optional[str]
             Give an username for Danse
     """
+    path = clean_path(path)
 
     duration = images.shape[0]
     height = images.shape[1]
     width = images.shape[2]
 
-    if path+defs.DoricFile.Dataset.IMAGE_STACK in f:
-        del f[path+defs.DoricFile.Dataset.IMAGE_STACK]
+    path_image_stack = f"{path}/{defs.DoricFile.Dataset.IMAGE_STACK}"
+    if path_image_stack in f:
+        del f[path_image_stack]
 
-    dataset = f.create_dataset(path+defs.DoricFile.Dataset.IMAGE_STACK, (height,width,duration), dtype="uint16",
+    image_stack_dataset = f.create_dataset(path_image_stack, (height,width,duration), dtype="uint16",
                                   chunks=(height,width,1), maxshape=(height,width,None))
 
     for i, image in enumerate(images):
-        dataset[:,:,i] = image
+        image_stack_dataset[:,:,i] = image
 
-    if path+defs.DoricFile.Dataset.TIME in f:
-        del f[path+defs.DoricFile.Dataset.TIME]
+    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
+    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
+    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.FORMAT]     = qt_format
+    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.HEIGHT]     = height
+    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.WIDTH]      = width
 
-    f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_.shape), maxshape=None)
+    path_time        = f"{path}/{defs.DoricFile.Dataset.TIME}"
+    if path_time in f:
+        del f[path_time]
 
-    f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
-    f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
-    f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.FORMAT]     = qt_format
-    f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.HEIGHT]     = height
-    f[path+defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.WIDTH]      = width
+    f.create_dataset(path_time, data=time_, dtype="float64", chunks=def_chunk_size(time_.shape), maxshape=None)
 
 
 def save_roi_signals(

--- a/utilities.py
+++ b/utilities.py
@@ -223,8 +223,7 @@ def save_roi_signals(
 
     """
 
-    if path[-1] != '/':
-        path += '/'
+    path = clean_path(path)
 
     for i in range(len(footprints)):
         coords = footprint_to_coords(footprints[i])
@@ -251,9 +250,9 @@ def save_roi_signals(
 
         dataset_name = defs.DoricFile.Dataset.ROI.format(str(i+1).zfill(4))
 
-        save_signal(signals[i], f, path+dataset_name, attrs)
+        save_signal(signals[i], f, f"{path}/{dataset_name}", attrs)
 
-    save_signal(time_, f, path+defs.DoricFile.Dataset.TIME)
+    save_signal(time_, f, f"{path}/{defs.DoricFile.Dataset.TIME}")
 
 
 def save_signal(
@@ -289,20 +288,20 @@ def save_signals(
     if bit_count is None and (range_min is None or range_max is None or unit is None):
         raise ValueError("Set either bits count attribute, or range min, range max, and unit attributes.")
 
-    if path[-1] != '/':
-        path += '/'
+    path = clean_path(path)
 
     try:
-        f.create_dataset(path+defs.DoricFile.Dataset.TIME, data=time_, dtype="float64", chunks=def_chunk_size(time_.shape), maxshape=None)
+        f.create_dataset(f"{path}/{defs.DoricFile.Dataset.TIME}", data=time_, dtype="float64", chunks=def_chunk_size(time_.shape), maxshape=None)
     except:
         pass
 
     for i,name in enumerate(names):
+        path_name = f"{path}/{name}"
 
-        if path+name in f:
-            del f[path+name]
+        if path_name in f:
+            del f[path_name]
 
-        f.create_dataset(path+name, data=signals[i], dtype="float64", chunks=def_chunk_size(signals[i].shape), maxshape=None)
+        f.create_dataset(path_name, data=signals[i], dtype="float64", chunks=def_chunk_size(signals[i].shape), maxshape=None)
 
         attrs = {}
 
@@ -316,7 +315,7 @@ def save_signals(
             attrs[defs.DoricFile.Attribute.Signal.UNIT]      = unit
 
         if attrs is not None:
-            save_attributes(attrs, f, path+name)
+            save_attributes(attrs, f, path_name)
 
 
 def save_attributes(
@@ -429,8 +428,7 @@ def print_to_intercept(msg):
 
 
 def print_group_path_for_DANSE(path):
-    if(path[-1] == "/"):
-        path = path[:-1]
+    path = clean_path(path)
 
     print_to_intercept(defs.Messages.PATHGROUP.format(path = f"/{path}"))
 

--- a/utilities.py
+++ b/utilities.py
@@ -167,17 +167,17 @@ def save_images(
     if path_image_stack in f:
         del f[path_image_stack]
 
-    image_stack_dataset = f.create_dataset(path_image_stack, (height,width,duration), dtype="uint16",
+    dataset = f.create_dataset(path_image_stack, (height,width,duration), dtype="uint16",
                                   chunks=(height,width,1), maxshape=(height,width,None))
 
     for i, image in enumerate(images):
-        image_stack_dataset[:,:,i] = image
+        dataset[:,:,i] = image
 
-    image_stack_dataset.attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
-    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
-    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.FORMAT]     = qt_format
-    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.HEIGHT]     = height
-    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.WIDTH]      = width
+    dataset.attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
+    dataset.attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
+    dataset.attrs[defs.DoricFile.Attribute.Image.FORMAT]     = qt_format
+    dataset.attrs[defs.DoricFile.Attribute.Image.HEIGHT]     = height
+    dataset.attrs[defs.DoricFile.Attribute.Image.WIDTH]      = width
 
     path_time        = f"{path}/{defs.DoricFile.Dataset.TIME}"
     if path_time in f:

--- a/utilities.py
+++ b/utilities.py
@@ -173,11 +173,11 @@ def save_images(
     for i, image in enumerate(images):
         image_stack_dataset[:,:,i] = image
 
-    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
-    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
-    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.FORMAT]     = qt_format
-    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.HEIGHT]     = height
-    image_stack_dataset[defs.DoricFile.Dataset.IMAGE_STACK].attrs[defs.DoricFile.Attribute.Image.WIDTH]      = width
+    image_stack_dataset.attrs[defs.DoricFile.Attribute.Dataset.USERNAME] = username
+    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.BIT_COUNT]  = bit_count
+    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.FORMAT]     = qt_format
+    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.HEIGHT]     = height
+    image_stack_dataset.attrs[defs.DoricFile.Attribute.Image.WIDTH]      = width
 
     path_time        = f"{path}/{defs.DoricFile.Dataset.TIME}"
     if path_time in f:


### PR DESCRIPTION
- Clean paths to always have the same structure `aaaa/bbbb/cccc` to avoid crash when giving path with wrong structure like `/aaa/bbb/ccc/` or `aaa/bbb/ccc`

- Do a bit of reworking of how paths are used.
  - Use variable if path is use multiple time so no need to do multiple `f"{path}/{dataset}"`
  - Use hdf5 dataset or group variable if possible when use multiple time like for `.attrs[]` definition