### PR TITLE
Fix bug with writing in folder

### DIFF
--- a/CaImAn/caiman_parameters.py
+++ b/CaImAn/caiman_parameters.py
@@ -1,5 +1,6 @@
 import h5py
 import sys
+import os
 import numpy as np
 from tifffile import imwrite
 
@@ -22,6 +23,8 @@ class CaimanParameters:
         self.params = danse_params.get(defs.Parameters.Main.PARAMETERS, {})
         self.preview_params = danse_params.get(defs.Parameters.Main.PREVIEW, {})
 
+        os.environ["CAIMAN_TEMP"] = self.paths[defs.Parameters.Path.TMP_DIR]
+
         self.paths[defs.Parameters.Path.H5PATH] = utils.clean_path(self.paths[defs.Parameters.Path.H5PATH][0])
 
         with h5py.File(self.paths[defs.Parameters.Path.FILEPATH], 'r') as file_:
@@ -34,7 +37,7 @@ class CaimanParameters:
         neuron_diameter = tuple([self.params[defs.Parameters.danse.NEURO_DIAM_MIN], self.params[defs.Parameters.danse.NEURO_DIAM_MAX]])
 
         print(cm_defs.Messages.WRITE_IMAGE_TIFF, flush=True)
-        fnames = self.paths[defs.Parameters.Path.TMP_DIR] + '/' + f"tiff_{'_'.join(self.get_h5path_names()[2:4])}.tif"
+        fnames = f"{self.paths[defs.Parameters.Path.TMP_DIR]}/tiff_{'_'.join(self.get_h5path_names()[2:4])}.tif"
         imwrite(fnames, images.transpose(2, 0, 1))
         del images
 
@@ -74,6 +77,7 @@ class CaimanParameters:
             "use_cnn": False,
             "fnames": fnames
         })
+
         self.params_cross_reg = {}
         if self.params.get(defs.Parameters.danse.CROSS_REG, False):
             self.params_cross_reg = {

--- a/CaImAn/caiman_parameters.py
+++ b/CaImAn/caiman_parameters.py
@@ -1,6 +1,5 @@
 import h5py
 import sys
-import os
 import numpy as np
 from tifffile import imwrite
 
@@ -22,8 +21,6 @@ class CaimanParameters:
         self.paths  = danse_params.get(defs.Parameters.Main.PATHS, {})
         self.params = danse_params.get(defs.Parameters.Main.PARAMETERS, {})
         self.preview_params = danse_params.get(defs.Parameters.Main.PREVIEW, {})
-
-        os.environ["CAIMAN_TEMP"] = self.paths[defs.Parameters.Path.TMP_DIR]
 
         self.paths[defs.Parameters.Path.H5PATH] = utils.clean_path(self.paths[defs.Parameters.Path.H5PATH][0])
 

--- a/CaImAn/caiman_run.py
+++ b/CaImAn/caiman_run.py
@@ -20,6 +20,7 @@ os.environ["CAIMAN_DATA"] = f"{os.path.dirname(os.path.abspath(__file__))}\\caim
 sys.path.append("..")
 # Import CaimAn related utilities libraries
 import utilities as utils
+import definitions as defs
 import caiman_definitions as cm_defs
 import caiman_parameters  as cm_params
 import caiman_main        as cm_main
@@ -49,6 +50,7 @@ except Exception as error:
 
 if __name__ == "__main__":
     caiman_params = cm_params.CaimanParameters(danse_parameters)
+    os.environ["CAIMAN_TEMP"] = caiman_params.paths[defs.Parameters.Path.TMP_DIR]
 
     if caiman_params.preview_params:
         cm_main.preview(caiman_params)


### PR DESCRIPTION
Some how now caiman don't have the right to write in folder `C:\Program Files\Doric Lenses\danse\libraries\caiman\_internal\caiman_data`.
So I set the default path to the temp folder created by Qt for preview as a path to save temporary data for caiman.

Because of info in` "caiman\paths.py"`
```python
def get_tempdir() -> str:
    """ Returns where CaImAn can store temporary files, such as memmap files. Controlled mainly by environment variables """
    # CAIMAN_TEMP is used to control where temporary files live. 
    # If unset, uses default of a temp folder under caiman_datadir()
    # To get the old "store it where I am" behaviour, set CAIMAN_TEMP to a single dot.
    # If you prefer to store it somewhere different, provide a full path to that location.
    logger = logging.getLogger("caiman")

...

```